### PR TITLE
net: nrf_provisioning: Fix upmerge issues

### DIFF
--- a/applications/nrf5340_audio/src/drivers/cs47l63_comm.c
+++ b/applications/nrf5340_audio/src/drivers/cs47l63_comm.c
@@ -34,7 +34,7 @@ static const struct gpio_dt_spec hw_codec_reset = GPIO_DT_SPEC_INST_GET(0, reset
 const static struct device *gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 
 static const struct spi_dt_spec spi = SPI_DT_SPEC_INST_GET(
-	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8) | SPI_LINES_SINGLE, 0);
+	0, SPI_OP_MODE_MASTER | SPI_TRANSFER_MSB | SPI_WORD_SET(8) | SPI_LINES_SINGLE);
 static bsp_callback_t bsp_callback;
 static void *bsp_callback_arg;
 

--- a/boards/nordic/nrf52820dongle/board.yml
+++ b/boards/nordic/nrf52820dongle/board.yml
@@ -1,5 +1,6 @@
 board:
   name: nrf52820dongle
+  full_name: nRF52820 Dongle
   vendor: nordic
   socs:
     - name: nrf52820

--- a/boards/nordic/nrf52833dongle/board.yml
+++ b/boards/nordic/nrf52833dongle/board.yml
@@ -1,5 +1,6 @@
 board:
   name: nrf52833dongle
+  full_name: nRF52833 Dongle
   vendor: nordic
   socs:
     - name: nrf52833

--- a/boards/nordic/nrf52840gmouse/board.yml
+++ b/boards/nordic/nrf52840gmouse/board.yml
@@ -1,5 +1,6 @@
 board:
   name: nrf52840gmouse
+  full_name: nRF52840 GMouse
   vendor: nordic
   socs:
     - name: nrf52840

--- a/boards/nordic/nrf52dmouse/board.yml
+++ b/boards/nordic/nrf52dmouse/board.yml
@@ -1,5 +1,6 @@
 board:
   name: nrf52dmouse
+  full_name: nRF52 DMouse
   vendor: nordic
   socs:
     - name: nrf52832

--- a/boards/nordic/nrf52kbd/board.yml
+++ b/boards/nordic/nrf52kbd/board.yml
@@ -1,5 +1,6 @@
 board:
   name: nrf52kbd
+  full_name: nRF52 Kbd
   vendor: nordic
   socs:
     - name: nrf52832

--- a/boards/nordic/nrf7120dk/board.yml
+++ b/boards/nordic/nrf7120dk/board.yml
@@ -1,5 +1,6 @@
 board:
   name: nrf7120dk
+  full_name: nRF7120 DK
   vendor: nordic
   socs:
   - name: nrf7120

--- a/boards/nordic/thingy91/board.yml
+++ b/boards/nordic/thingy91/board.yml
@@ -1,5 +1,6 @@
 board:
   name: thingy91
+  full_name: "Thingy:91"
   vendor: nordic
   socs:
     - name: nrf52840

--- a/boards/nordic/thingy91x/board.yml
+++ b/boards/nordic/thingy91x/board.yml
@@ -1,5 +1,6 @@
 board:
   name: thingy91x
+  full_name: "Thingy:91 X"
   vendor: nordic
   socs:
     - name: nrf9151

--- a/drivers/sensor/bme68x_iaq/bme68x_iaq.c
+++ b/drivers/sensor/bme68x_iaq/bme68x_iaq.c
@@ -694,7 +694,7 @@ static const struct sensor_driver_api bme68x_driver_api = {
 /* there can be only one device supported here because of BSECs internal state */
 static struct bme68x_iaq_config config_0 = {
 #if BME68x_BUS_SPI
-	.spi = SPI_DT_SPEC_INST_GET(0, BME68x_SPI_OPERATION, 0),
+	.spi = SPI_DT_SPEC_INST_GET(0, BME68x_SPI_OPERATION),
 #elif BME68x_BUS_I2C
 	.i2c = I2C_DT_SPEC_INST_GET(0),
 #endif

--- a/dts/common/nordic/nrf54ls05b.dtsi
+++ b/dts/common/nordic/nrf54ls05b.dtsi
@@ -175,7 +175,7 @@
 				status = "disabled";
 				dfe-supported;
 				ble-2mbps-supported;
-				cs-supported;
+				ble-cs-supported;
 
 				ieee802154: ieee802154 {
 					compatible = "nordic,nrf-ieee802154";

--- a/dts/common/nordic/nrf54lv10a.dtsi
+++ b/dts/common/nordic/nrf54lv10a.dtsi
@@ -217,7 +217,7 @@
 				ieee802154-supported;
 				ble-2mbps-supported;
 				ble-coded-phy-supported;
-				cs-supported;
+				ble-cs-supported;
 
 				ieee802154: ieee802154 {
 					compatible = "nordic,nrf-ieee802154";

--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -1698,13 +1698,13 @@ struct lte_lc_pdn_dynamic_info {
 	/** IPv6 Maximum Transmission Unit. */
 	uint32_t ipv6_mtu;
 	/** Primary IPv4 DNS address. */
-	struct in_addr dns_addr4_primary;
+	struct net_in_addr dns_addr4_primary;
 	/** Secondary IPv4 DNS address. */
-	struct in_addr dns_addr4_secondary;
+	struct net_in_addr dns_addr4_secondary;
 	/** Primary IPv6 DNS address. */
-	struct in6_addr dns_addr6_primary;
+	struct net_in6_addr dns_addr6_primary;
 	/** Secondary IPv6 DNS address. */
-	struct in6_addr dns_addr6_secondary;
+	struct net_in6_addr dns_addr6_secondary;
 };
 
 /** Authentication method. */

--- a/lib/date_time/date_time_modem.c
+++ b/lib/date_time/date_time_modem.c
@@ -5,8 +5,8 @@
  */
 
 #include <date_time.h>
+#include <time.h>
 #include <zephyr/kernel.h>
-#include <zephyr/posix/time.h>
 #include <zephyr/sys/timeutil.h>
 #include <zephyr/logging/log.h>
 #include <nrf_modem_at.h>

--- a/samples/cellular/modem_shell/prj.conf
+++ b/samples/cellular/modem_shell/prj.conf
@@ -44,9 +44,7 @@ CONFIG_FPU=y
 CONFIG_CJSON_LIB=y
 
 # Getopt
-CONFIG_GETOPT_LIB=y
-# Need to disable devmem shell since it enforces Zephyr's internal version of getopt
-CONFIG_DEVMEM_SHELL=n
+CONFIG_GETOPT_LONG=y
 
 # Device power management
 CONFIG_PM_DEVICE=y

--- a/samples/cellular/modem_shell/src/at/at_cmd_mode.c
+++ b/samples/cellular/modem_shell/src/at/at_cmd_mode.c
@@ -254,8 +254,10 @@ send:
 /* ctrl + q */
 #define CHAR_DC1 0x11
 
-static void at_cmd_mode_bypass_cb(const struct shell *sh, uint8_t *recv, size_t len)
+static void at_cmd_mode_bypass_cb(const struct shell *sh, uint8_t *recv, size_t len,
+				  void *user_data)
 {
+	ARG_UNUSED(user_data);
 	static uint8_t tail;
 	bool escape = false;
 
@@ -276,7 +278,7 @@ static void at_cmd_mode_bypass_cb(const struct shell *sh, uint8_t *recv, size_t 
 		printk("===========================================================\n");
 		printk("MoSh AT command mode exited\n");
 
-		shell_set_bypass(sh, NULL);
+		shell_set_bypass(sh, NULL, NULL);
 		at_cmd_mode_dont_print = false;
 		at_monitor_pause(&mosh_at_cmd_mode_handler);
 		at_cmd_mode_active = false;
@@ -326,7 +328,7 @@ int at_cmd_mode_start(const struct shell *sh)
 	at_cmd_mode_active = true;
 
 	at_monitor_resume(&mosh_at_cmd_mode_handler);
-	shell_set_bypass(sh, at_cmd_mode_bypass_cb);
+	shell_set_bypass(sh, at_cmd_mode_bypass_cb, NULL);
 
 	return 0;
 }

--- a/samples/cellular/modem_shell/src/link/link_shell.c
+++ b/samples/cellular/modem_shell/src/link/link_shell.c
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <getopt.h>
 
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>
+#include <zephyr/sys/sys_getopt.h>
 #include <zephyr/sys/poweroff.h>
 
 #include <nrf_modem_at.h>
@@ -465,87 +466,87 @@ enum {
 };
 
 /* Specifying the expected options (both long and short) */
-static struct option long_options[] = {
-	{ "help", no_argument, 0, 'h' },
-	{ "apn", required_argument, 0, 'a' },
-	{ "cid", required_argument, 0, 'I' },
-	{ "family", required_argument, 0, 'f' },
-	{ "ipaddr", required_argument, 0, 'i' },
-	{ "subscribe", no_argument, 0, 's' },
-	{ "unsubscribe", no_argument, 0, 'u' },
-	{ "read", no_argument, 0, 'r' },
-	{ "write", no_argument, 0, LINK_SHELL_OPT_WRITE },
-	{ "pwroff", no_argument, 0, '0' },
-	{ "normal", no_argument, 0, '1' },
-	{ "rxonly", no_argument, 0, '2' },
-	{ "flightmode", no_argument, 0, '4' },
-	{ "lteoff", no_argument, 0, LINK_SHELL_OPT_FUNMODE_LTEOFF },
-	{ "lteon", no_argument, 0, LINK_SHELL_OPT_FUNMODE_LTEON },
-	{ "gnssoff", no_argument, 0, LINK_SHELL_OPT_FUNMODE_GNSSOFF },
-	{ "gnsson", no_argument, 0, LINK_SHELL_OPT_FUNMODE_GNSSON },
-	{ "uiccoff", no_argument, 0, LINK_SHELL_OPT_FUNMODE_UICCOFF },
-	{ "uiccon", no_argument, 0, LINK_SHELL_OPT_FUNMODE_UICCON },
-	{ "flightmode_uiccon", no_argument, 0, LINK_SHELL_OPT_FUNMODE_FLIGHTMODE_UICCON },
-	{ "flightmode_keepreg", no_argument, 0, LINK_SHELL_OPT_FUNMODE_FLIGHTMODE_KEEPREG },
-	{ "flightmode_keepreg_uiccon", no_argument, 0,
+static struct sys_getopt_option long_options[] = {
+	{ "help", sys_getopt_no_argument, 0, 'h' },
+	{ "apn", sys_getopt_required_argument, 0, 'a' },
+	{ "cid", sys_getopt_required_argument, 0, 'I' },
+	{ "family", sys_getopt_required_argument, 0, 'f' },
+	{ "ipaddr", sys_getopt_required_argument, 0, 'i' },
+	{ "subscribe", sys_getopt_no_argument, 0, 's' },
+	{ "unsubscribe", sys_getopt_no_argument, 0, 'u' },
+	{ "read", sys_getopt_no_argument, 0, 'r' },
+	{ "write", sys_getopt_no_argument, 0, LINK_SHELL_OPT_WRITE },
+	{ "pwroff", sys_getopt_no_argument, 0, '0' },
+	{ "normal", sys_getopt_no_argument, 0, '1' },
+	{ "rxonly", sys_getopt_no_argument, 0, '2' },
+	{ "flightmode", sys_getopt_no_argument, 0, '4' },
+	{ "lteoff", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_LTEOFF },
+	{ "lteon", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_LTEON },
+	{ "gnssoff", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_GNSSOFF },
+	{ "gnsson", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_GNSSON },
+	{ "uiccoff", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_UICCOFF },
+	{ "uiccon", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_UICCON },
+	{ "flightmode_uiccon", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_FLIGHTMODE_UICCON },
+	{ "flightmode_keepreg", sys_getopt_no_argument, 0, LINK_SHELL_OPT_FUNMODE_FLIGHTMODE_KEEPREG },
+	{ "flightmode_keepreg_uiccon", sys_getopt_no_argument, 0,
 	  LINK_SHELL_OPT_FUNMODE_FLIGHTMODE_KEEPREG_UICCON },
-	{ "ltem", no_argument, 0, 'm' },
-	{ "nbiot", no_argument, 0, 'n' },
-	{ "gnss", no_argument, 0, 'g' },
-	{ "ltem_gnss", no_argument, 0, 'M' },
-	{ "nbiot_gnss", no_argument, 0, 'N' },
-	{ "enable", no_argument, 0, 'e' },
-	{ "enable_no_rel14", no_argument, 0, LINK_SHELL_OPT_NMODE_NO_REL14 },
-	{ "disable", no_argument, 0, 'd' },
-	{ "ltem_edrx", required_argument, 0, LINK_SHELL_OPT_LTEM_EDRX },
-	{ "ltem_ptw", required_argument, 0, LINK_SHELL_OPT_LTEM_PTW },
-	{ "nbiot_edrx", required_argument, 0, LINK_SHELL_OPT_NBIOT_EDRX },
-	{ "nbiot_ptw", required_argument, 0, LINK_SHELL_OPT_NBIOT_PTW },
-	{ "ntn_nbiot_edrx", required_argument, 0, LINK_SHELL_OPT_NTN_NBIOT_EDRX },
-	{ "ntn_nbiot_ptw", required_argument, 0, LINK_SHELL_OPT_NTN_NBIOT_PTW },
-	{ "prot", required_argument, 0, 'A' },
-	{ "pword", required_argument, 0, 'P' },
-	{ "uname", required_argument, 0, 'U' },
-	{ "rptau", required_argument, 0, 'p' },
-	{ "rat", required_argument, 0, 't' },
-	{ "srptau", required_argument, 0, 'P' },
-	{ "srat", required_argument, 0, 'T' },
-	{ "mem1", required_argument, 0, LINK_SHELL_OPT_MEM_SLOT_1 },
-	{ "mem2", required_argument, 0, LINK_SHELL_OPT_MEM_SLOT_2 },
-	{ "mem3", required_argument, 0, LINK_SHELL_OPT_MEM_SLOT_3 },
-	{ "reset", no_argument, 0, LINK_SHELL_OPT_RESET },
-	{ "clear", no_argument, 0, LINK_SHELL_OPT_RESET },
-	{ "mreset_all", no_argument, 0, LINK_SHELL_OPT_MRESET_ALL },
-	{ "mreset_user", no_argument, 0, LINK_SHELL_OPT_MRESET_USER },
-	{ "ltem_nbiot", no_argument, 0, LINK_SHELL_OPT_SYSMODE_LTEM_NBIOT },
-	{ "ltem_nbiot_gnss", no_argument, 0, LINK_SHELL_OPT_SYSMODE_LTEM_NBIOT_GNSS },
-	{ "ntn", no_argument, 0, LINK_SHELL_OPT_SYSMODE_NTN },
-	{ "pref_auto", no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_AUTO },
-	{ "pref_ltem", no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_LTEM },
-	{ "pref_nbiot", no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_NBIOT },
-	{ "pref_ltem_plmn_prio", no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_LTEM_PLMN_PRIO },
-	{ "pref_nbiot_plmn_prio", no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_NBIOT_PLMN_PRIO },
-	{ "start", no_argument, 0, LINK_SHELL_OPT_START },
-	{ "stop", no_argument, 0, LINK_SHELL_OPT_STOP },
-	{ "cancel", no_argument, 0, LINK_SHELL_OPT_STOP },
-	{ "single", no_argument, 0, LINK_SHELL_OPT_SINGLE },
-	{ "continuous", no_argument, 0, LINK_SHELL_OPT_CONTINUOUS },
-	{ "threshold", required_argument, 0, LINK_SHELL_OPT_THRESHOLD_TIME },
-	{ "interval", required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_CONTINUOUS_INTERVAL_TIME },
-	{ "gci_count", required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_GCI_COUNT },
-	{ "search_type", required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_SEARCH_TYPE },
-	{ "search_cfg", required_argument, 0, LINK_SHELL_OPT_SEARCH_CFG },
-	{ "search_pattern_range", required_argument, 0, LINK_SHELL_OPT_SEARCH_PATTERN_RANGE },
-	{ "search_pattern_table", required_argument, 0, LINK_SHELL_OPT_SEARCH_PATTERN_TABLE },
-	{ "normal_no_rel14", no_argument, 0, LINK_SHELL_OPT_NMODE_NO_REL14 },
-	{ "default", no_argument, 0, LINK_SHELL_OPT_REDMOB_DEFAULT },
-	{ "nordic", no_argument, 0, LINK_SHELL_OPT_REDMOB_NORDIC },
-	{ "init", no_argument, 0, LINK_SHELL_OPT_MODEM_INIT },
-	{ "shutdown", no_argument, 0, LINK_SHELL_OPT_MODEM_SHUTDOWN },
-	{ "shutdown_cfun0", no_argument, 0, LINK_SHELL_OPT_MODEM_SHUTDOWN_CFUN0 },
-	{ "systemoff", no_argument, 0, LINK_SHELL_OPT_MODEM_SYSTEMOFF },
-	{ "eval_type", required_argument, 0, LINK_SHELL_OPT_ENVEVAL_EVAL_TYPE },
-	{ "plmns", required_argument, 0, LINK_SHELL_OPT_ENVEVAL_PLMNS },
+	{ "ltem", sys_getopt_no_argument, 0, 'm' },
+	{ "nbiot", sys_getopt_no_argument, 0, 'n' },
+	{ "gnss", sys_getopt_no_argument, 0, 'g' },
+	{ "ltem_gnss", sys_getopt_no_argument, 0, 'M' },
+	{ "nbiot_gnss", sys_getopt_no_argument, 0, 'N' },
+	{ "enable", sys_getopt_no_argument, 0, 'e' },
+	{ "enable_no_rel14", sys_getopt_no_argument, 0, LINK_SHELL_OPT_NMODE_NO_REL14 },
+	{ "disable", sys_getopt_no_argument, 0, 'd' },
+	{ "ltem_edrx", sys_getopt_required_argument, 0, LINK_SHELL_OPT_LTEM_EDRX },
+	{ "ltem_ptw", sys_getopt_required_argument, 0, LINK_SHELL_OPT_LTEM_PTW },
+	{ "nbiot_edrx", sys_getopt_required_argument, 0, LINK_SHELL_OPT_NBIOT_EDRX },
+	{ "nbiot_ptw", sys_getopt_required_argument, 0, LINK_SHELL_OPT_NBIOT_PTW },
+	{ "ntn_nbiot_edrx", sys_getopt_required_argument, 0, LINK_SHELL_OPT_NTN_NBIOT_EDRX },
+	{ "ntn_nbiot_ptw", sys_getopt_required_argument, 0, LINK_SHELL_OPT_NTN_NBIOT_PTW },
+	{ "prot", sys_getopt_required_argument, 0, 'A' },
+	{ "pword", sys_getopt_required_argument, 0, 'P' },
+	{ "uname", sys_getopt_required_argument, 0, 'U' },
+	{ "rptau", sys_getopt_required_argument, 0, 'p' },
+	{ "rat", sys_getopt_required_argument, 0, 't' },
+	{ "srptau", sys_getopt_required_argument, 0, 'P' },
+	{ "srat", sys_getopt_required_argument, 0, 'T' },
+	{ "mem1", sys_getopt_required_argument, 0, LINK_SHELL_OPT_MEM_SLOT_1 },
+	{ "mem2", sys_getopt_required_argument, 0, LINK_SHELL_OPT_MEM_SLOT_2 },
+	{ "mem3", sys_getopt_required_argument, 0, LINK_SHELL_OPT_MEM_SLOT_3 },
+	{ "reset", sys_getopt_no_argument, 0, LINK_SHELL_OPT_RESET },
+	{ "clear", sys_getopt_no_argument, 0, LINK_SHELL_OPT_RESET },
+	{ "mreset_all", sys_getopt_no_argument, 0, LINK_SHELL_OPT_MRESET_ALL },
+	{ "mreset_user", sys_getopt_no_argument, 0, LINK_SHELL_OPT_MRESET_USER },
+	{ "ltem_nbiot", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_LTEM_NBIOT },
+	{ "ltem_nbiot_gnss", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_LTEM_NBIOT_GNSS },
+	{ "ntn", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_NTN },
+	{ "pref_auto", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_AUTO },
+	{ "pref_ltem", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_LTEM },
+	{ "pref_nbiot", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_NBIOT },
+	{ "pref_ltem_plmn_prio", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_LTEM_PLMN_PRIO },
+	{ "pref_nbiot_plmn_prio", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SYSMODE_PREF_NBIOT_PLMN_PRIO },
+	{ "start", sys_getopt_no_argument, 0, LINK_SHELL_OPT_START },
+	{ "stop", sys_getopt_no_argument, 0, LINK_SHELL_OPT_STOP },
+	{ "cancel", sys_getopt_no_argument, 0, LINK_SHELL_OPT_STOP },
+	{ "single", sys_getopt_no_argument, 0, LINK_SHELL_OPT_SINGLE },
+	{ "continuous", sys_getopt_no_argument, 0, LINK_SHELL_OPT_CONTINUOUS },
+	{ "threshold", sys_getopt_required_argument, 0, LINK_SHELL_OPT_THRESHOLD_TIME },
+	{ "interval", sys_getopt_required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_CONTINUOUS_INTERVAL_TIME },
+	{ "gci_count", sys_getopt_required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_GCI_COUNT },
+	{ "search_type", sys_getopt_required_argument, 0, LINK_SHELL_OPT_NCELLMEAS_SEARCH_TYPE },
+	{ "search_cfg", sys_getopt_required_argument, 0, LINK_SHELL_OPT_SEARCH_CFG },
+	{ "search_pattern_range", sys_getopt_required_argument, 0, LINK_SHELL_OPT_SEARCH_PATTERN_RANGE },
+	{ "search_pattern_table", sys_getopt_required_argument, 0, LINK_SHELL_OPT_SEARCH_PATTERN_TABLE },
+	{ "normal_no_rel14", sys_getopt_no_argument, 0, LINK_SHELL_OPT_NMODE_NO_REL14 },
+	{ "default", sys_getopt_no_argument, 0, LINK_SHELL_OPT_REDMOB_DEFAULT },
+	{ "nordic", sys_getopt_no_argument, 0, LINK_SHELL_OPT_REDMOB_NORDIC },
+	{ "init", sys_getopt_no_argument, 0, LINK_SHELL_OPT_MODEM_INIT },
+	{ "shutdown", sys_getopt_no_argument, 0, LINK_SHELL_OPT_MODEM_SHUTDOWN },
+	{ "shutdown_cfun0", sys_getopt_no_argument, 0, LINK_SHELL_OPT_MODEM_SHUTDOWN_CFUN0 },
+	{ "systemoff", sys_getopt_no_argument, 0, LINK_SHELL_OPT_MODEM_SYSTEMOFF },
+	{ "eval_type", sys_getopt_required_argument, 0, LINK_SHELL_OPT_ENVEVAL_EVAL_TYPE },
+	{ "plmns", sys_getopt_required_argument, 0, LINK_SHELL_OPT_ENVEVAL_PLMNS },
 	{ 0, 0, 0, 0 }
 };
 
@@ -799,49 +800,49 @@ static int link_shell_connect(const struct shell *shell, size_t argc, char **arg
 		goto show_usage;
 	}
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'a': /* APN */
-			apn_len = strlen(optarg);
+			apn_len = strlen(sys_getopt_optarg);
 			if (apn_len > LINK_APN_STR_MAX_LENGTH) {
 				mosh_error(
 					"APN string length %d exceeded. Maximum is %d.",
 					apn_len, LINK_APN_STR_MAX_LENGTH);
 				return -EINVAL;
 			}
-			apn = optarg;
+			apn = sys_getopt_optarg;
 			break;
 		case 'f': /* Address family */
-			family = optarg;
+			family = sys_getopt_optarg;
 			break;
 		case 'i': /* IP address */
-			ip_address = optarg;
+			ip_address = sys_getopt_optarg;
 			break;
 		case 'A': /* auth protocol */
-			protocol = atoi(optarg);
+			protocol = atoi(sys_getopt_optarg);
 			protocol_given = true;
 			break;
 		case 'U': /* auth username */
-			username = optarg;
+			username = sys_getopt_optarg;
 			break;
 		case 'P': /* auth password */
-			password = optarg;
+			password = sys_getopt_optarg;
 			break;
 
 		case 'h':
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -988,14 +989,14 @@ static int link_shell_enveval(const struct shell *shell, size_t argc, char **arg
 		goto show_usage;
 	}
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case LINK_SHELL_OPT_ENVEVAL_EVAL_TYPE:
-			params.eval_type = link_shell_string_to_env_eval_type(optarg);
+			params.eval_type = link_shell_string_to_env_eval_type(sys_getopt_optarg);
 			if (params.eval_type == MOSH_ENVEVAL_EVAL_TYPE_NONE) {
 				mosh_error("Unknown evaluation type. See usage:");
 				goto show_usage;
@@ -1003,7 +1004,7 @@ static int link_shell_enveval(const struct shell *shell, size_t argc, char **arg
 			break;
 		case LINK_SHELL_OPT_ENVEVAL_PLMNS:
 			ret = link_shell_string_to_env_eval_plmn_list(
-				optarg, params.plmn_list, &params.plmn_count);
+				sys_getopt_optarg, params.plmn_list, &params.plmn_count);
 			if (ret) {
 				mosh_error("Invalid PLMN list. See usage:");
 				goto show_usage;
@@ -1017,7 +1018,7 @@ static int link_shell_enveval(const struct shell *shell, size_t argc, char **arg
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
@@ -1067,11 +1068,11 @@ static int link_shell_defcont(const struct shell *shell, size_t argc, char **arg
 	char *apn = NULL;
 	char *family = NULL;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -1084,29 +1085,29 @@ static int link_shell_defcont(const struct shell *shell, size_t argc, char **arg
 			break;
 
 		case 'a': /* APN */
-			apn_len = strlen(optarg);
+			apn_len = strlen(sys_getopt_optarg);
 			if (apn_len > LINK_APN_STR_MAX_LENGTH) {
 				mosh_error(
 					"APN string length %d exceeded. Maximum is %d.",
 					apn_len, LINK_APN_STR_MAX_LENGTH);
 				return -EINVAL;
 			}
-			apn = optarg;
+			apn = sys_getopt_optarg;
 			break;
 		case 'f': /* Address family */
-			family = optarg;
+			family = sys_getopt_optarg;
 			break;
 
 		case 'h':
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1157,11 +1158,11 @@ static int link_shell_defcontauth(const struct shell *shell, size_t argc, char *
 	char *username = NULL;
 	char *password = NULL;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -1174,26 +1175,26 @@ static int link_shell_defcontauth(const struct shell *shell, size_t argc, char *
 			break;
 
 		case 'A': /* auth protocol */
-			protocol = atoi(optarg);
+			protocol = atoi(sys_getopt_optarg);
 			protocol_given = true;
 			break;
 		case 'U': /* auth username */
-			username = optarg;
+			username = sys_getopt_optarg;
 			break;
 		case 'P': /* auth password */
-			password = optarg;
+			password = sys_getopt_optarg;
 			break;
 
 		case 'h':
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1236,14 +1237,14 @@ static int link_shell_disconnect(const struct shell *shell, size_t argc, char **
 	int ret = 0;
 	int pdn_cid = 0;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'I': /* PDN CID */
-			pdn_cid = atoi(optarg);
+			pdn_cid = atoi(sys_getopt_optarg);
 			if (pdn_cid <= 0) {
 				mosh_error(
 					"PDN CID (%d) must be positive integer. "
@@ -1257,12 +1258,12 @@ static int link_shell_disconnect(const struct shell *shell, size_t argc, char **
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1286,11 +1287,11 @@ static int link_shell_dnsaddr(const struct shell *shell, size_t argc, char **arg
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 	char *ip_address = NULL;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -1303,19 +1304,19 @@ static int link_shell_dnsaddr(const struct shell *shell, size_t argc, char **arg
 			break;
 
 		case 'i':
-			ip_address = optarg;
+			ip_address = sys_getopt_optarg;
 			break;
 
 		case 'h':
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1375,11 +1376,11 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 	char ntn_nbiot_ptw_str[LINK_SHELL_EDRX_PTW_STR_LENGTH + 1];
 	bool ntn_nbiot_ptw_set = false;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -1392,8 +1393,8 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case LINK_SHELL_OPT_LTEM_EDRX:
-			if (strlen(optarg) == LINK_SHELL_EDRX_VALUE_STR_LENGTH) {
-				strcpy(ltem_edrx_str, optarg);
+			if (strlen(sys_getopt_optarg) == LINK_SHELL_EDRX_VALUE_STR_LENGTH) {
+				strcpy(ltem_edrx_str, sys_getopt_optarg);
 				ltem_edrx_set = true;
 			} else {
 				mosh_error(
@@ -1403,8 +1404,8 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case LINK_SHELL_OPT_LTEM_PTW:
-			if (strlen(optarg) == LINK_SHELL_EDRX_PTW_STR_LENGTH) {
-				strcpy(ltem_ptw_str, optarg);
+			if (strlen(sys_getopt_optarg) == LINK_SHELL_EDRX_PTW_STR_LENGTH) {
+				strcpy(ltem_ptw_str, sys_getopt_optarg);
 				ltem_ptw_set = true;
 			} else {
 				mosh_error(
@@ -1414,8 +1415,8 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case LINK_SHELL_OPT_NBIOT_EDRX:
-			if (strlen(optarg) == LINK_SHELL_EDRX_VALUE_STR_LENGTH) {
-				strcpy(nbiot_edrx_str, optarg);
+			if (strlen(sys_getopt_optarg) == LINK_SHELL_EDRX_VALUE_STR_LENGTH) {
+				strcpy(nbiot_edrx_str, sys_getopt_optarg);
 				nbiot_edrx_set = true;
 			} else {
 				mosh_error(
@@ -1425,8 +1426,8 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case LINK_SHELL_OPT_NBIOT_PTW:
-			if (strlen(optarg) == LINK_SHELL_EDRX_PTW_STR_LENGTH) {
-				strcpy(nbiot_ptw_str, optarg);
+			if (strlen(sys_getopt_optarg) == LINK_SHELL_EDRX_PTW_STR_LENGTH) {
+				strcpy(nbiot_ptw_str, sys_getopt_optarg);
 				nbiot_ptw_set = true;
 			} else {
 				mosh_error(
@@ -1436,8 +1437,8 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case LINK_SHELL_OPT_NTN_NBIOT_EDRX:
-			if (strlen(optarg) == LINK_SHELL_EDRX_VALUE_STR_LENGTH) {
-				strcpy(ntn_nbiot_edrx_str, optarg);
+			if (strlen(sys_getopt_optarg) == LINK_SHELL_EDRX_VALUE_STR_LENGTH) {
+				strcpy(ntn_nbiot_edrx_str, sys_getopt_optarg);
 				ntn_nbiot_edrx_set = true;
 			} else {
 				mosh_error(
@@ -1447,8 +1448,8 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case LINK_SHELL_OPT_NTN_NBIOT_PTW:
-			if (strlen(optarg) == LINK_SHELL_EDRX_PTW_STR_LENGTH) {
-				strcpy(ntn_nbiot_ptw_str, optarg);
+			if (strlen(sys_getopt_optarg) == LINK_SHELL_EDRX_PTW_STR_LENGTH) {
+				strcpy(ntn_nbiot_ptw_str, sys_getopt_optarg);
 				ntn_nbiot_ptw_set = true;
 			} else {
 				mosh_error(
@@ -1462,12 +1463,12 @@ static int link_shell_edrx(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1608,11 +1609,11 @@ static int link_shell_funmode(const struct shell *shell, size_t argc, char **arg
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 	char snum[64];
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		/* This condition prevents accidentally using two functional modes */
 		if (funmode_option != LINK_FUNMODE_NONE) {
 			mosh_error("Use only one option when setting functional mode");
@@ -1675,12 +1676,12 @@ static int link_shell_funmode(const struct shell *shell, size_t argc, char **arg
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1718,11 +1719,11 @@ static int link_shell_modem(const struct shell *shell, size_t argc, char **argv)
 {
 	bool operation_selected = false;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case LINK_SHELL_OPT_MODEM_INIT:
 			operation_selected = true;
@@ -1754,12 +1755,12 @@ static int link_shell_modem(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1780,11 +1781,11 @@ static int link_shell_msleep(const struct shell *shell, size_t argc, char **argv
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 	int threshold_time = 0;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 's':
 		case 'u':
@@ -1796,7 +1797,7 @@ static int link_shell_msleep(const struct shell *shell, size_t argc, char **argv
 			break;
 
 		case LINK_SHELL_OPT_THRESHOLD_TIME:
-			threshold_time = atoi(optarg);
+			threshold_time = atoi(sys_getopt_optarg);
 			if (threshold_time <= 0) {
 				mosh_error(
 					"Not a valid number for --threshold_time (milliseconds).");
@@ -1808,12 +1809,12 @@ static int link_shell_msleep(const struct shell *shell, size_t argc, char **argv
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1851,11 +1852,11 @@ static int link_shell_ncellmeas(const struct shell *shell, size_t argc, char **a
 	bool periodic_time_given = false;
 	int gci_count;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case LINK_SHELL_OPT_STOP:
 			operation = LINK_OPERATION_STOP;
@@ -1868,14 +1869,14 @@ static int link_shell_ncellmeas(const struct shell *shell, size_t argc, char **a
 			ncellmeasmode = LINK_NCELLMEAS_MODE_CONTINUOUS;
 			break;
 		case LINK_SHELL_OPT_NCELLMEAS_SEARCH_TYPE:
-			ncellmeas_search_type = link_shell_string_to_ncellmeas_search_type(optarg);
+			ncellmeas_search_type = link_shell_string_to_ncellmeas_search_type(sys_getopt_optarg);
 			if (ncellmeas_search_type == MOSH_NCELLMEAS_SEARCH_TYPE_NONE) {
 				mosh_error("Unknown search_type. See usage:");
 				goto show_usage;
 			}
 			break;
 		case LINK_SHELL_OPT_NCELLMEAS_GCI_COUNT:
-			gci_count = atoi(optarg);
+			gci_count = atoi(sys_getopt_optarg);
 			if (gci_count <= 0) {
 				mosh_error("Not a valid number for --gci_count.");
 				return -EINVAL;
@@ -1885,8 +1886,8 @@ static int link_shell_ncellmeas(const struct shell *shell, size_t argc, char **a
 		case LINK_SHELL_OPT_NCELLMEAS_CONTINUOUS_INTERVAL_TIME: {
 			char *end_ptr;
 
-			periodic_time = strtol(optarg, &end_ptr, 10);
-			if (end_ptr == optarg || periodic_time < 0) {
+			periodic_time = strtol(sys_getopt_optarg, &end_ptr, 10);
+			if (end_ptr == sys_getopt_optarg || periodic_time < 0) {
 				mosh_error("Not a valid number for --interval (seconds).");
 				return -EINVAL;
 			}
@@ -1898,12 +1899,12 @@ static int link_shell_ncellmeas(const struct shell *shell, size_t argc, char **a
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1933,25 +1934,25 @@ static int link_shell_nmodeat(const struct shell *shell, size_t argc, char **arg
 	char *normal_mode_at_str = NULL;
 	uint8_t normal_mode_at_mem_slot = 0;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 			operation = LINK_OPERATION_READ;
 			break;
 		case LINK_SHELL_OPT_MEM_SLOT_1:
-			normal_mode_at_str = optarg;
+			normal_mode_at_str = sys_getopt_optarg;
 			normal_mode_at_mem_slot = 1;
 			break;
 		case LINK_SHELL_OPT_MEM_SLOT_2:
-			normal_mode_at_str = optarg;
+			normal_mode_at_str = sys_getopt_optarg;
 			normal_mode_at_mem_slot = 2;
 			break;
 		case LINK_SHELL_OPT_MEM_SLOT_3:
-			normal_mode_at_str = optarg;
+			normal_mode_at_str = sys_getopt_optarg;
 			normal_mode_at_mem_slot = 3;
 			break;
 
@@ -1959,12 +1960,12 @@ static int link_shell_nmodeat(const struct shell *shell, size_t argc, char **arg
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2000,11 +2001,11 @@ static int link_shell_nmodeauto(const struct shell *shell, size_t argc, char **a
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 	bool nmode_use_rel14 = true;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -2025,12 +2026,12 @@ static int link_shell_nmodeauto(const struct shell *shell, size_t argc, char **a
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2057,11 +2058,11 @@ static int link_shell_propripsm(const struct shell *shell, size_t argc, char **a
 	int err;
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -2073,12 +2074,12 @@ static int link_shell_propripsm(const struct shell *shell, size_t argc, char **a
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2123,11 +2124,11 @@ static int link_shell_psm(const struct shell *shell, size_t argc, char **argv)
 	int psm_rat_seconds = 0;
 	bool psm_rat_seconds_set = false;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -2140,9 +2141,9 @@ static int link_shell_psm(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case 'p': /* rptau */
-			if (strlen(optarg) ==
+			if (strlen(sys_getopt_optarg) ==
 			    LINK_SHELL_PSM_PARAM_STR_LENGTH) {
-				strcpy(psm_rptau_bit_str, optarg);
+				strcpy(psm_rptau_bit_str, sys_getopt_optarg);
 				psm_rptau_bit_str_set = true;
 			} else {
 				mosh_error(
@@ -2152,9 +2153,9 @@ static int link_shell_psm(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 't': /* rat */
-			if (strlen(optarg) ==
+			if (strlen(sys_getopt_optarg) ==
 			    LINK_SHELL_PSM_PARAM_STR_LENGTH) {
-				strcpy(psm_rat_bit_str, optarg);
+				strcpy(psm_rat_bit_str, sys_getopt_optarg);
 				psm_rat_bit_str_set = true;
 			} else {
 				mosh_error(
@@ -2165,11 +2166,11 @@ static int link_shell_psm(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case 'P': /* rptau in seconds */
-			psm_rptau_seconds = atoi(optarg);
+			psm_rptau_seconds = atoi(sys_getopt_optarg);
 			psm_rptau_seconds_set = true;
 			break;
 		case 'T': /* rat in seconds */
-			psm_rat_seconds = atoi(optarg);
+			psm_rat_seconds = atoi(sys_getopt_optarg);
 			psm_rat_seconds_set = true;
 			break;
 
@@ -2177,12 +2178,12 @@ static int link_shell_psm(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2272,11 +2273,11 @@ static int link_shell_rai(const struct shell *shell, size_t argc, char **argv)
 {
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'e':
@@ -2292,12 +2293,12 @@ static int link_shell_rai(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2326,11 +2327,11 @@ static int link_shell_redmob(const struct shell *shell, size_t argc, char **argv
 	enum link_reduced_mobility_mode redmob_mode = LINK_REDUCED_MOBILITY_NONE;
 	char snum[10];
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case 'd':
@@ -2352,12 +2353,12 @@ static int link_shell_redmob(const struct shell *shell, size_t argc, char **argv
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2402,11 +2403,11 @@ static int link_shell_rsrp(const struct shell *shell, size_t argc, char **argv)
 {
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 's':
 		case 'u':
@@ -2421,12 +2422,12 @@ static int link_shell_rsrp(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2453,11 +2454,11 @@ static int link_shell_search(const struct shell *shell, size_t argc, char **argv
 	struct lte_lc_periodic_search_cfg search_cfg = { 0 };
 	bool search_cfg_given = false;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case LINK_SHELL_OPT_START:
@@ -2476,7 +2477,7 @@ static int link_shell_search(const struct shell *shell, size_t argc, char **argv
 			int loop_integer = 0;
 
 			ret = sscanf(
-				optarg,
+				sys_getopt_optarg,
 				"%d,%hd,%hd",
 				&loop_integer,
 				&search_cfg.return_to_pattern,
@@ -2507,7 +2508,7 @@ static int link_shell_search(const struct shell *shell, size_t argc, char **argv
 			int index = search_cfg.pattern_count;
 
 			ret = sscanf(
-				optarg,
+				sys_getopt_optarg,
 				"%hd,%hd,%hd,%hd",
 				&search_cfg.patterns[index].range.initial_sleep,
 				&search_cfg.patterns[index].range.final_sleep,
@@ -2536,7 +2537,7 @@ static int link_shell_search(const struct shell *shell, size_t argc, char **argv
 			search_cfg.patterns[index].table.val_5 = -1;
 
 			ret = sscanf(
-				optarg,
+				sys_getopt_optarg,
 				"%d,%d,%d,%d,%d",
 				&search_cfg.patterns[index].table.val_1,
 				&search_cfg.patterns[index].table.val_2,
@@ -2562,12 +2563,12 @@ static int link_shell_search(const struct shell *shell, size_t argc, char **argv
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2683,11 +2684,11 @@ static int link_shell_settings(const struct shell *shell, size_t argc, char **ar
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 	enum link_factory_reset_type mreset_type = LINK_FACTORY_RESET_INVALID;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case LINK_SHELL_OPT_RESET:
@@ -2709,12 +2710,12 @@ static int link_shell_settings(const struct shell *shell, size_t argc, char **ar
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2784,11 +2785,11 @@ static int link_shell_sysmode(const struct shell *shell, size_t argc, char **arg
 	enum lte_lc_system_mode_preference sysmode_lte_pref_option = LTE_LC_SYSTEM_MODE_PREFER_AUTO;
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 		case LINK_SHELL_OPT_RESET:
@@ -2843,12 +2844,12 @@ static int link_shell_sysmode(const struct shell *shell, size_t argc, char **arg
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -2910,11 +2911,11 @@ static int link_shell_tau(const struct shell *shell, size_t argc, char **argv)
 	enum link_shell_operation operation = LINK_OPERATION_NONE;
 	int threshold_time = 0;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		switch (opt) {
 		case 's':
 		case 'u':
@@ -2922,7 +2923,7 @@ static int link_shell_tau(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case LINK_SHELL_OPT_THRESHOLD_TIME:
-			threshold_time = atoi(optarg);
+			threshold_time = atoi(sys_getopt_optarg);
 			if (threshold_time <= 0) {
 				mosh_error(
 					"Not a valid number for --threshold_time (milliseconds).");
@@ -2934,12 +2935,12 @@ static int link_shell_tau(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}

--- a/samples/cellular/modem_shell/src/location/location_details.c
+++ b/samples/cellular/modem_shell/src/location/location_details.c
@@ -12,7 +12,7 @@
 #include <date_time.h>
 #include <cJSON.h>
 #include <math.h>
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 #include <modem/lte_lc.h>
 #include <net/nrf_cloud.h>
 

--- a/samples/cellular/modem_shell/src/location/location_shell.c
+++ b/samples/cellular/modem_shell/src/location/location_shell.c
@@ -12,7 +12,7 @@
 #ifdef CONFIG_POSIX_C_LIB_EXT
 #include <zephyr/posix/unistd.h>
 #endif
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 #include <net/nrf_cloud.h>
 #if defined(CONFIG_NRF_CLOUD_REST)
 #include <net/nrf_cloud_rest.h>
@@ -136,24 +136,24 @@ enum {
 };
 
 /* Specifying the expected options */
-static struct option long_options[] = {
-	{ "method", required_argument, 0, 'm' },
-	{ "mode", required_argument, 0, LOCATION_SHELL_OPT_MODE },
-	{ "interval", required_argument, 0, LOCATION_SHELL_OPT_INTERVAL },
-	{ "timeout", required_argument, 0, 't' },
-	{ "gnss_accuracy", required_argument, 0, LOCATION_SHELL_OPT_GNSS_ACCURACY },
-	{ "gnss_timeout", required_argument, 0, LOCATION_SHELL_OPT_GNSS_TIMEOUT },
-	{ "gnss_num_fixes", required_argument, 0, LOCATION_SHELL_OPT_GNSS_NUM_FIXES },
-	{ "gnss_visibility", no_argument, 0, LOCATION_SHELL_OPT_GNSS_VISIBILITY },
-	{ "gnss_priority", no_argument, 0, LOCATION_SHELL_OPT_GNSS_PRIORITY_MODE },
-	{ "gnss_cloud_nmea", no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_NMEA },
-	{ "gnss_cloud_pvt", no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_PVT },
-	{ "cloud_details", no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_DETAILS },
-	{ "cellular_timeout", required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_TIMEOUT },
-	{ "cellular_cell_count", required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_CELL_COUNT },
-	{ "cloud_resp_disabled", no_argument, 0, LOCATION_SHELL_OPT_CLOUD_RESP_DISABLED },
-	{ "wifi_timeout", required_argument, 0, LOCATION_SHELL_OPT_WIFI_TIMEOUT },
-	{ "help", no_argument, 0, 'h' },
+static struct sys_getopt_option long_options[] = {
+	{ "method", sys_getopt_required_argument, 0, 'm' },
+	{ "mode", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_MODE },
+	{ "interval", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_INTERVAL },
+	{ "timeout", sys_getopt_required_argument, 0, 't' },
+	{ "gnss_accuracy", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_GNSS_ACCURACY },
+	{ "gnss_timeout", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_GNSS_TIMEOUT },
+	{ "gnss_num_fixes", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_GNSS_NUM_FIXES },
+	{ "gnss_visibility", sys_getopt_no_argument, 0, LOCATION_SHELL_OPT_GNSS_VISIBILITY },
+	{ "gnss_priority", sys_getopt_no_argument, 0, LOCATION_SHELL_OPT_GNSS_PRIORITY_MODE },
+	{ "gnss_cloud_nmea", sys_getopt_no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_NMEA },
+	{ "gnss_cloud_pvt", sys_getopt_no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_PVT },
+	{ "cloud_details", sys_getopt_no_argument, 0, LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_DETAILS },
+	{ "cellular_timeout", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_TIMEOUT },
+	{ "cellular_cell_count", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_CELLULAR_CELL_COUNT },
+	{ "cloud_resp_disabled", sys_getopt_no_argument, 0, LOCATION_SHELL_OPT_CLOUD_RESP_DISABLED },
+	{ "wifi_timeout", sys_getopt_required_argument, 0, LOCATION_SHELL_OPT_WIFI_TIMEOUT },
+	{ "help", sys_getopt_no_argument, 0, 'h' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -532,19 +532,19 @@ static int cmd_location_get(const struct shell *shell, size_t argc, char **argv)
 	arg_cloud_details = false;
 	arg_cloud_resp_enabled = true;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "m:t:h", long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "m:t:h", long_options, NULL)) != -1) {
 		switch (opt) {
 		case LOCATION_SHELL_OPT_GNSS_TIMEOUT:
-			gnss_timeout = atof(optarg);
+			gnss_timeout = atof(sys_getopt_optarg);
 			gnss_timeout_set = true;
 			break;
 
 		case LOCATION_SHELL_OPT_GNSS_NUM_FIXES:
-			gnss_num_fixes = atoi(optarg);
+			gnss_num_fixes = atoi(sys_getopt_optarg);
 			gnss_num_fixes_set = true;
 			break;
 		case LOCATION_SHELL_OPT_GNSS_LOC_CLOUD_NMEA:
@@ -565,11 +565,11 @@ static int cmd_location_get(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case LOCATION_SHELL_OPT_CELLULAR_TIMEOUT:
-			cellular_timeout = atof(optarg);
+			cellular_timeout = atof(sys_getopt_optarg);
 			cellular_timeout_set = true;
 			break;
 		case LOCATION_SHELL_OPT_CELLULAR_CELL_COUNT:
-			cellular_cell_count = atoi(optarg);
+			cellular_cell_count = atoi(sys_getopt_optarg);
 			cellular_cell_count_set = true;
 			break;
 		case LOCATION_SHELL_OPT_CLOUD_RESP_DISABLED:
@@ -584,25 +584,25 @@ static int cmd_location_get(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case LOCATION_SHELL_OPT_WIFI_TIMEOUT:
-			wifi_timeout = atof(optarg);
+			wifi_timeout = atof(sys_getopt_optarg);
 			wifi_timeout_set = true;
 			break;
 
 		case LOCATION_SHELL_OPT_INTERVAL:
-			interval = atoi(optarg);
+			interval = atoi(sys_getopt_optarg);
 			interval_set = true;
 			break;
 		case 't':
-			timeout = atof(optarg);
+			timeout = atof(sys_getopt_optarg);
 			timeout_set = true;
 			break;
 
 		case LOCATION_SHELL_OPT_GNSS_ACCURACY:
-			if (strcmp(optarg, "low") == 0) {
+			if (strcmp(sys_getopt_optarg, "low") == 0) {
 				gnss_accuracy = LOCATION_ACCURACY_LOW;
-			} else if (strcmp(optarg, "normal") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "normal") == 0) {
 				gnss_accuracy = LOCATION_ACCURACY_NORMAL;
-			} else if (strcmp(optarg, "high") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "high") == 0) {
 				gnss_accuracy = LOCATION_ACCURACY_HIGH;
 			} else {
 				mosh_error("Unknown GNSS accuracy. See usage:");
@@ -620,14 +620,14 @@ static int cmd_location_get(const struct shell *shell, size_t argc, char **argv)
 			break;
 
 		case LOCATION_SHELL_OPT_MODE:
-			if (strcmp(optarg, "fallback") == 0) {
+			if (strcmp(sys_getopt_optarg, "fallback") == 0) {
 				req_mode = LOCATION_REQ_MODE_FALLBACK;
-			} else if (strcmp(optarg, "all") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "all") == 0) {
 				req_mode = LOCATION_REQ_MODE_ALL;
 			} else {
 				mosh_error(
 					"Unknown location request mode (%s) was given. See usage:",
-						optarg);
+						sys_getopt_optarg);
 				goto show_usage;
 			}
 			break;
@@ -637,18 +637,18 @@ static int cmd_location_get(const struct shell *shell, size_t argc, char **argv)
 				mosh_error(
 					"Maximum number of location methods (%d) exceeded. "
 					"Location method (%s) still given.",
-					CONFIG_LOCATION_METHODS_LIST_SIZE, optarg);
+					CONFIG_LOCATION_METHODS_LIST_SIZE, sys_getopt_optarg);
 				return -EINVAL;
 			}
 
-			if (strcmp(optarg, "cellular") == 0) {
+			if (strcmp(sys_getopt_optarg, "cellular") == 0) {
 				method_list[method_count] = LOCATION_METHOD_CELLULAR;
-			} else if (strcmp(optarg, "gnss") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "gnss") == 0) {
 				method_list[method_count] = LOCATION_METHOD_GNSS;
-			} else if (strcmp(optarg, "wifi") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "wifi") == 0) {
 				method_list[method_count] = LOCATION_METHOD_WIFI;
 			} else {
-				mosh_error("Unknown method (%s) given. See usage:", optarg);
+				mosh_error("Unknown method (%s) given. See usage:", sys_getopt_optarg);
 				goto show_usage;
 			}
 			method_count++;
@@ -658,12 +658,12 @@ static int cmd_location_get(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}

--- a/samples/cellular/modem_shell/src/ping/icmp_ping_print.c
+++ b/samples/cellular/modem_shell/src/ping/icmp_ping_print.c
@@ -7,10 +7,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <assert.h>
 
 #include <zephyr/kernel.h>
-#include <zephyr/posix/time.h>
 #include <zephyr/sys/cbprintf.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>

--- a/samples/cellular/modem_shell/src/ping/icmp_ping_shell.c
+++ b/samples/cellular/modem_shell/src/ping/icmp_ping_shell.c
@@ -11,7 +11,7 @@
 #ifdef CONFIG_POSIX_C_LIB_EXT
 #include <zephyr/posix/unistd.h>
 #endif
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 
 #include "link_api.h"
 #include "mosh_print.h"
@@ -37,16 +37,16 @@ static const char icmp_ping_shell_cmd_usage_str[] =
 	"  -h, --help,              Shows this help information";
 
 /* Specifying the expected options (both long and short) */
-static struct option long_options[] = {
-	{ "destination", required_argument, 0, 'd' },
-	{ "timeout", required_argument, 0, 't' },
-	{ "count", required_argument, 0, 'c' },
-	{ "interval", required_argument, 0, 'i' },
-	{ "length", required_argument, 0, 'l' },
-	{ "cid", required_argument, 0, 'I' },
-	{ "ipv6", no_argument, 0, '6' },
-	{ "rai", no_argument, 0, 'r' },
-	{ "help", no_argument, 0, 'h' },
+static struct sys_getopt_option long_options[] = {
+	{ "destination", sys_getopt_required_argument, 0, 'd' },
+	{ "timeout", sys_getopt_required_argument, 0, 't' },
+	{ "count", sys_getopt_required_argument, 0, 'c' },
+	{ "interval", sys_getopt_required_argument, 0, 'i' },
+	{ "length", sys_getopt_required_argument, 0, 'l' },
+	{ "cid", sys_getopt_required_argument, 0, 'I' },
+	{ "ipv6", sys_getopt_no_argument, 0, '6' },
+	{ "rai", sys_getopt_no_argument, 0, 'r' },
+	{ "help", sys_getopt_no_argument, 0, 'h' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -81,23 +81,23 @@ int icmp_ping_shell_th(const struct shell *shell, size_t argc, char **argv,
 	}
 #endif
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "d:t:c:i:I:l:h6r", long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "d:t:c:i:I:l:h6r", long_options, NULL)) != -1) {
 
 		switch (opt) {
 		case 'd': /* destination */
-			dest_len = strlen(optarg);
+			dest_len = strlen(sys_getopt_optarg);
 			if (dest_len > ICMP_MAX_ADDR) {
 				ping_error(&ping_args, "too long destination name");
 				goto show_usage;
 			}
-			strcpy(ping_args.target_name, optarg);
+			strcpy(ping_args.target_name, sys_getopt_optarg);
 			break;
 		case 't': /* timeout */
-			ping_args.timeout = atoi(optarg);
+			ping_args.timeout = atoi(sys_getopt_optarg);
 			if (ping_args.timeout == 0) {
 				ping_warn(
 					&ping_args,
@@ -107,14 +107,14 @@ int icmp_ping_shell_th(const struct shell *shell, size_t argc, char **argv,
 			}
 			break;
 		case 'I': /* PDN CID */
-			ping_args.cid = atoi(optarg);
+			ping_args.cid = atoi(sys_getopt_optarg);
 			if (ping_args.cid == 0) {
 				ping_warn(&ping_args, "CID not an integer (> 0), default context used");
 				ping_args.cid = MOSH_ARG_NOT_SET;
 			}
 			break;
 		case 'c': /* count */
-			ping_args.count = atoi(optarg);
+			ping_args.count = atoi(sys_getopt_optarg);
 			if (ping_args.count == 0) {
 				ping_warn(
 					&ping_args,
@@ -124,7 +124,7 @@ int icmp_ping_shell_th(const struct shell *shell, size_t argc, char **argv,
 			}
 			break;
 		case 'i': /* interval */
-			ping_args.interval = atoi(optarg);
+			ping_args.interval = atoi(sys_getopt_optarg);
 			if (ping_args.interval == 0) {
 				ping_warn(
 					&ping_args,
@@ -134,7 +134,7 @@ int icmp_ping_shell_th(const struct shell *shell, size_t argc, char **argv,
 			}
 			break;
 		case 'l': /* payload length */
-			ping_args.len = atoi(optarg);
+			ping_args.len = atoi(sys_getopt_optarg);
 			if (ping_args.len > ICMP_IPV4_MAX_LEN) {
 				ping_error(
 					&ping_args,
@@ -169,12 +169,12 @@ int icmp_ping_shell_th(const struct shell *shell, size_t argc, char **argv,
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}

--- a/samples/cellular/modem_shell/src/ppp/ppp_shell.c
+++ b/samples/cellular/modem_shell/src/ppp/ppp_shell.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <zephyr/shell/shell.h>
 #include <unistd.h>
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 
 #include <zephyr/net/promiscuous.h>
 #include <zephyr/drivers/uart.h>
@@ -31,14 +31,16 @@ static const char ppp_uartconf_usage_str[] =
 	"  -h, --help,            Shows this help information";
 
 /* Specifying the expected options (both long and short) */
-static struct option long_options[] = { { "baudrate", required_argument, 0, 'b' },
-					{ "databits", required_argument, 0, 'd' },
-					{ "stopbits", required_argument, 0, 's' },
-					{ "parity", required_argument, 0, 'p' },
-					{ "flowctrl", required_argument, 0, 'f' },
-					{ "read", no_argument, 0, 'r' },
-					{ "help", no_argument, 0, 'h' },
-					{ 0, 0, 0, 0 } };
+static struct sys_getopt_option long_options[] = {
+	{ "baudrate", sys_getopt_required_argument, 0, 'b' },
+	{ "databits", sys_getopt_required_argument, 0, 'd' },
+	{ "stopbits", sys_getopt_required_argument, 0, 's' },
+	{ "parity", sys_getopt_required_argument, 0, 'p' },
+	{ "flowctrl", sys_getopt_required_argument, 0, 'f' },
+	{ "read", sys_getopt_no_argument, 0, 'r' },
+	{ "help", sys_getopt_no_argument, 0, 'h' },
+	{ 0, 0, 0, 0 }
+};
 
 static void ppp_shell_uart_conf_print(struct uart_config *ppp_uart_config)
 {
@@ -144,14 +146,14 @@ static int cmd_ppp_uartconf(const struct shell *shell, size_t argc, char **argv)
 		goto show_usage;
 	}
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "b:d:s:p:f:rh", long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "b:d:s:p:f:rh", long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'b':
-			ret = atoi(optarg);
+			ret = atoi(sys_getopt_optarg);
 			switch (ret) {
 			case 1200:
 			case 2400:
@@ -175,7 +177,7 @@ static int cmd_ppp_uartconf(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'd':
-			ret = atoi(optarg);
+			ret = atoi(sys_getopt_optarg);
 			data_bits_set = true;
 			uartconf_option_given = true;
 			switch (ret) {
@@ -192,7 +194,7 @@ static int cmd_ppp_uartconf(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 's':
-			ret = atoi(optarg);
+			ret = atoi(sys_getopt_optarg);
 			stop_bits_set = true;
 			uartconf_option_given = true;
 			switch (ret) {
@@ -211,14 +213,14 @@ static int cmd_ppp_uartconf(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'p':
-			ret = atoi(optarg);
+			ret = atoi(sys_getopt_optarg);
 			parity_set = true;
 			uartconf_option_given = true;
-			if (strcmp(optarg, "none") == 0) {
+			if (strcmp(sys_getopt_optarg, "none") == 0) {
 				parity = UART_CFG_PARITY_NONE;
-			} else if (strcmp(optarg, "odd") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "odd") == 0) {
 				parity = UART_CFG_PARITY_ODD;
-			} else if (strcmp(optarg, "even") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "even") == 0) {
 				parity = UART_CFG_PARITY_EVEN;
 			} else {
 				mosh_error("Unsupported parity config");
@@ -227,13 +229,13 @@ static int cmd_ppp_uartconf(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'f':
-			ret = atoi(optarg);
+			ret = atoi(sys_getopt_optarg);
 			flow_ctrl_set = true;
 			uartconf_option_given = true;
-			if (strcmp(optarg, "none") == 0) {
+			if (strcmp(sys_getopt_optarg, "none") == 0) {
 				flow_ctrl = UART_CFG_FLOW_CTRL_NONE;
-			} else if (strcmp(optarg, "rts_cts") == 0 ||
-				   strcmp(optarg, "RTS_CTS") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "rts_cts") == 0 ||
+				   strcmp(sys_getopt_optarg, "RTS_CTS") == 0) {
 				flow_ctrl = UART_CFG_FLOW_CTRL_RTS_CTS;
 			} else {
 				mosh_error("Unsupported flow ctrl config");
@@ -249,12 +251,12 @@ static int cmd_ppp_uartconf(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}

--- a/samples/cellular/modem_shell/src/rest/rest_shell.c
+++ b/samples/cellular/modem_shell/src/rest/rest_shell.c
@@ -12,7 +12,7 @@
 #ifdef CONFIG_POSIX_C_LIB_EXT
 #include <zephyr/posix/unistd.h>
 #endif
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 
 #include <zephyr/net/http/parser.h>
 #include <net/rest_client.h>
@@ -54,21 +54,21 @@ enum {
 };
 
 /* Specifying the expected options (both long and short) */
-static struct option long_options[] = {
-	{ "host", required_argument, 0, 'd' },
-	{ "port", required_argument, 0, 'p' },
-	{ "url", required_argument, 0, 'u' },
-	{ "body", required_argument, 0, 'b' },
-	{ "resp_len", required_argument, 0, 'l' },
-	{ "header", required_argument, 0, 'H' },
-	{ "method", required_argument, 0, 'm' },
-	{ "sec_tag", required_argument, 0, 's' },
-	{ "peer_verify", required_argument, 0, 'v' },
-	{ "timeout", required_argument, 0, 't' },
-	{ "keepalive", no_argument, 0, 'k' },
-	{ "sckt_id", required_argument, 0, 'i' },
-	{ "help", no_argument, 0, 'h' },
-	{ "print_headers", no_argument, 0, REST_SHELL_OPT_PRINT_RESP_HEADERS },
+static struct sys_getopt_option long_options[] = {
+	{ "host", sys_getopt_required_argument, 0, 'd' },
+	{ "port", sys_getopt_required_argument, 0, 'p' },
+	{ "url", sys_getopt_required_argument, 0, 'u' },
+	{ "body", sys_getopt_required_argument, 0, 'b' },
+	{ "resp_len", sys_getopt_required_argument, 0, 'l' },
+	{ "header", sys_getopt_required_argument, 0, 'H' },
+	{ "method", sys_getopt_required_argument, 0, 'm' },
+	{ "sec_tag", sys_getopt_required_argument, 0, 's' },
+	{ "peer_verify", sys_getopt_required_argument, 0, 'v' },
+	{ "timeout", sys_getopt_required_argument, 0, 't' },
+	{ "keepalive", sys_getopt_no_argument, 0, 'k' },
+	{ "sckt_id", sys_getopt_required_argument, 0, 'i' },
+	{ "help", sys_getopt_no_argument, 0, 'h' },
+	{ "print_headers", sys_getopt_no_argument, 0, REST_SHELL_OPT_PRINT_RESP_HEADERS },
 	{ 0, 0, 0, 0 }
 };
 
@@ -108,25 +108,25 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 	req_ctx.body = NULL;
 	memset(req_headers, 0, (REST_REQUEST_MAX_HEADERS + 1) * sizeof(char *));
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "d:p:b:H:m:s:u:v:t:l:i:kh", long_options,
+	while ((opt = sys_getopt_long(argc, argv, "d:p:b:H:m:s:u:v:t:l:i:kh", long_options,
 				  NULL)) != -1) {
 		switch (opt) {
 		case 'm':
-			if (strcmp(optarg, "get") == 0) {
+			if (strcmp(sys_getopt_optarg, "get") == 0) {
 				req_ctx.http_method = HTTP_GET;
-			} else if (strcmp(optarg, "head") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "head") == 0) {
 				req_ctx.http_method = HTTP_HEAD;
-			} else if (strcmp(optarg, "post") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "post") == 0) {
 				req_ctx.http_method = HTTP_POST;
-			} else if (strcmp(optarg, "put") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "put") == 0) {
 				req_ctx.http_method = HTTP_PUT;
-			} else if (strcmp(optarg, "delete") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "delete") == 0) {
 				req_ctx.http_method = HTTP_DELETE;
-			} else if (strcmp(optarg, "patch") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "patch") == 0) {
 				req_ctx.http_method = HTTP_PATCH;
 			} else {
 				mosh_error("Unsupported HTTP request method");
@@ -139,17 +139,17 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 			req_ctx.keep_alive = true;
 			break;
 		case 'd':
-			req_ctx.host = optarg;
+			req_ctx.host = sys_getopt_optarg;
 			host_set = true;
 			break;
 		case 'u':
-			req_ctx.url = optarg;
+			req_ctx.url = sys_getopt_optarg;
 			break;
 		case 'i':
-			req_ctx.connect_socket = atoi(optarg);
+			req_ctx.connect_socket = atoi(sys_getopt_optarg);
 			break;
 		case 's':
-			req_ctx.sec_tag = atoi(optarg);
+			req_ctx.sec_tag = atoi(sys_getopt_optarg);
 			if (req_ctx.sec_tag == 0) {
 				mosh_warn("sec_tag not an integer (!= 0)");
 				ret = -EINVAL;
@@ -157,7 +157,7 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'l':
-			response_buf_len = atoi(optarg);
+			response_buf_len = atoi(sys_getopt_optarg);
 			if (response_buf_len == 0) {
 				mosh_warn("response buffer length not an integer (> 0)");
 				ret = -EINVAL;
@@ -165,13 +165,13 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 't':
-			req_ctx.timeout_ms = atoi(optarg);
+			req_ctx.timeout_ms = atoi(sys_getopt_optarg);
 			if (req_ctx.timeout_ms == 0) {
 				req_ctx.timeout_ms = SYS_FOREVER_MS;
 			}
 			break;
 		case 'p':
-			req_ctx.port = atoi(optarg);
+			req_ctx.port = atoi(sys_getopt_optarg);
 			if (req_ctx.port == 0) {
 				mosh_warn("port not an integer (> 0)");
 				ret = -EINVAL;
@@ -179,7 +179,7 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'b':
-			len = strlen(optarg);
+			len = strlen(sys_getopt_optarg);
 			if (len > 0) {
 				req_ctx.body = k_malloc(len + 1);
 				if (req_ctx.body == NULL) {
@@ -187,13 +187,13 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 					ret = -ENOMEM;
 					goto end;
 				}
-				strcpy((char *)req_ctx.body, optarg);
+				strcpy((char *)req_ctx.body, sys_getopt_optarg);
 			}
 			break;
 		case 'H': {
 			bool room_available = false;
 
-			len = strlen(optarg);
+			len = strlen(sys_getopt_optarg);
 			if (len <= 0) {
 				mosh_error("No header given");
 				ret = -EINVAL;
@@ -215,18 +215,18 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 				goto end;
 			}
 
-			req_headers[i] = k_malloc(strlen(optarg) + 1);
+			req_headers[i] = k_malloc(strlen(sys_getopt_optarg) + 1);
 			if (req_headers[i] == NULL) {
-				mosh_error("Cannot allocate memory for header %s", optarg);
+				mosh_error("Cannot allocate memory for header %s", sys_getopt_optarg);
 				ret = -ENOMEM;
 				goto end;
 			}
 			headers_set = true;
-			strcpy(req_headers[i], optarg);
+			strcpy(req_headers[i], sys_getopt_optarg);
 			break;
 		}
 		case 'v':
-			req_ctx.tls_peer_verify = atoi(optarg);
+			req_ctx.tls_peer_verify = atoi(sys_getopt_optarg);
 			if (req_ctx.tls_peer_verify < 0 || req_ctx.tls_peer_verify > 2) {
 				mosh_error(
 					"Valid values for peer verify (%d) are 0, 1 and 2.",
@@ -244,13 +244,13 @@ static int rest_shell(const struct shell *shell, size_t argc, char **argv)
 			goto end;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			show_usage = true;
 			goto end;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		show_usage = true;
 		goto end;

--- a/samples/cellular/modem_shell/src/sms/sms_shell.c
+++ b/samples/cellular/modem_shell/src/sms/sms_shell.c
@@ -11,7 +11,7 @@
 #ifdef CONFIG_POSIX_C_LIB_EXT
 #include <zephyr/posix/unistd.h>
 #endif
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 #include <modem/sms.h>
 
 #include "sms.h"
@@ -56,13 +56,13 @@ static const char sms_recv_usage_str[] =
 	"  -h, --help,          Shows this help information";
 
 /* Specifying the expected options (both long and short) */
-static struct option long_options[] = {
-	{ "message",    required_argument, 0, 'm' },
-	{ "number",     required_argument, 0, 'n' },
-	{ "start",      no_argument,       0, 'r' },
-	{ "type",       no_argument,       0, 't' },
-	{ "help",       no_argument,       0, 'h' },
-	{ 0,            0,                 0, 0   }
+static struct sys_getopt_option long_options[] = {
+	{ "message",    sys_getopt_required_argument, 0, 'm' },
+	{ "number",     sys_getopt_required_argument, 0, 'n' },
+	{ "start",      sys_getopt_no_argument,       0, 'r' },
+	{ "type",       sys_getopt_required_argument, 0, 't' },
+	{ "help",       sys_getopt_no_argument,       0, 'h' },
+	{ 0,            0,                            0, 0   }
 };
 
 static void sms_print_usage(enum sms_shell_command command)
@@ -95,39 +95,39 @@ static int cmd_sms_send(const struct shell *shell, size_t argc, char **argv)
 	memset(arg_number, 0, SMS_MAX_MESSAGE_LEN + 1);
 	memset(arg_message, 0, SMS_MAX_MESSAGE_LEN + 1);
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "m:n:t:h", long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "m:n:t:h", long_options, NULL)) != -1) {
 		int send_data_len = 0;
 
 		switch (opt) {
 		case 'n': /* Phone number */
-			strcpy(arg_number, optarg);
+			strcpy(arg_number, sys_getopt_optarg);
 			break;
 		case 'm': /* Message text */
-			send_data_len = strlen(optarg);
+			send_data_len = strlen(sys_getopt_optarg);
 			if (send_data_len > SMS_MAX_MESSAGE_LEN) {
 				mosh_error(
 					"Data length %d exceeded. Maximum is %d. Given data: %s",
 					send_data_len,
 					SMS_MAX_MESSAGE_LEN,
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
-			strcpy(arg_message, optarg);
+			strcpy(arg_message, sys_getopt_optarg);
 			break;
 		case 't': /* Message data type */
-			if (!strcmp(optarg, "ascii")) {
+			if (!strcmp(sys_getopt_optarg, "ascii")) {
 				arg_message_type = SMS_DATA_TYPE_ASCII;
-			} else if (!strcmp(optarg, "gsm7bit")) {
+			} else if (!strcmp(sys_getopt_optarg, "gsm7bit")) {
 				arg_message_type = SMS_DATA_TYPE_GSM7BIT;
 			} else {
 				mosh_error(
 					"Unsupported message type=%s. Supported values are: "
 					"'ascii' or 'gsm7bit'",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
@@ -136,12 +136,12 @@ static int cmd_sms_send(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -162,11 +162,11 @@ static int cmd_sms_recv(const struct shell *shell, size_t argc, char **argv)
 	/* Variables for command line arguments */
 	bool arg_receive_start = false;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "rh", long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "rh", long_options, NULL)) != -1) {
 
 		switch (opt) {
 		case 'r': /* Start monitoring received messages */
@@ -176,12 +176,12 @@ static int cmd_sms_recv(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}

--- a/samples/cellular/modem_shell/src/sock/sock_shell.c
+++ b/samples/cellular/modem_shell/src/sock/sock_shell.c
@@ -13,7 +13,7 @@
 #include <sys/socket.h>
 #include <zephyr/net/tls_credentials.h>
 #include <fcntl.h>
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 
 #include "sock.h"
 #include "mosh_defines.h"
@@ -250,42 +250,42 @@ static const char sock_level_list_str[] =
 #define SOCK_SHELL_OPT_SOCKET_OPTION_LEVEL 206
 
 /* Specifying the expected options (both long and short) */
-static struct option long_options[] = {
-	{ "id",             required_argument, 0, 'i' },
-	{ "cid",            required_argument, 0, 'I' },
-	{ "address",        required_argument, 0, 'a' },
-	{ "port",           required_argument, 0, 'p' },
-	{ "family",         required_argument, 0, 'f' },
-	{ "type",           required_argument, 0, 't' },
-	{ "bind_port",      required_argument, 0, 'b' },
-	{ "secure",         no_argument,       0, 'S' },
-	{ "sec_tag",        required_argument, 0, 'T' },
-	{ "cache",          no_argument,       0, 'c' },
-	{ "peer_verify",    required_argument, 0, 'V' },
-	{ "hostname",       required_argument, 0, 'H' },
-	{ "dtls_cid",       required_argument, 0, 'C' },
-	{ "dtls_frag_ext",  required_argument, 0, 'F' },
-	{ "data",           required_argument, 0, 'd' },
-	{ "length",         required_argument, 0, 'l' },
-	{ "period",         required_argument, 0, 'e' },
-	{ "buffer_size",    required_argument, 0, 's' },
-	{ "hex",            no_argument,       0, 'x' },
-	{ "start",          no_argument,       0, 'r' },
-	{ "blocking",       required_argument, 0, 'B' },
-	{ "wait_ack",       no_argument,       0, 'W' },
-	{ "keep_open",      no_argument,       0, 'K' },
-	{ "print_format",   required_argument, 0, 'P' },
-	{ "option",         required_argument, 0, 'o' },
-	{ "value",          required_argument, 0, 'v' },
-	{ "level",          required_argument, 0, SOCK_SHELL_OPT_SOCKET_OPTION_LEVEL },
-	{ "packet_number_prefix", no_argument, 0, SOCK_SHELL_OPT_PACKET_NUMBER_PREFIX },
-	{ "rai_last",       no_argument,       0, SOCK_SHELL_OPT_RAI_LAST },
-	{ "rai_no_data",    no_argument,       0, SOCK_SHELL_OPT_RAI_NO_DATA },
-	{ "rai_one_resp",   no_argument,       0, SOCK_SHELL_OPT_RAI_ONE_RESP },
-	{ "rai_ongoing",    no_argument,       0, SOCK_SHELL_OPT_RAI_ONGOING },
-	{ "rai_wait_more",  no_argument,       0, SOCK_SHELL_OPT_RAI_WAIT_MORE },
-	{ "help",           no_argument,       0, 'h' },
-	{ 0,                0,                 0, 0   }
+static struct sys_getopt_option long_options[] = {
+	{ "id",             sys_getopt_required_argument, 0, 'i' },
+	{ "cid",            sys_getopt_required_argument, 0, 'I' },
+	{ "address",        sys_getopt_required_argument, 0, 'a' },
+	{ "port",           sys_getopt_required_argument, 0, 'p' },
+	{ "family",         sys_getopt_required_argument, 0, 'f' },
+	{ "type",           sys_getopt_required_argument, 0, 't' },
+	{ "bind_port",      sys_getopt_required_argument, 0, 'b' },
+	{ "secure",         sys_getopt_no_argument,       0, 'S' },
+	{ "sec_tag",        sys_getopt_required_argument, 0, 'T' },
+	{ "cache",          sys_getopt_no_argument,       0, 'c' },
+	{ "peer_verify",    sys_getopt_required_argument, 0, 'V' },
+	{ "hostname",       sys_getopt_required_argument, 0, 'H' },
+	{ "dtls_cid",       sys_getopt_required_argument, 0, 'C' },
+	{ "dtls_frag_ext",  sys_getopt_required_argument, 0, 'F' },
+	{ "data",           sys_getopt_required_argument, 0, 'd' },
+	{ "length",         sys_getopt_required_argument, 0, 'l' },
+	{ "period",         sys_getopt_required_argument, 0, 'e' },
+	{ "buffer_size",    sys_getopt_required_argument, 0, 's' },
+	{ "hex",            sys_getopt_no_argument,       0, 'x' },
+	{ "start",          sys_getopt_no_argument,       0, 'r' },
+	{ "blocking",       sys_getopt_required_argument, 0, 'B' },
+	{ "wait_ack",       sys_getopt_no_argument,       0, 'W' },
+	{ "keep_open",      sys_getopt_no_argument,       0, 'K' },
+	{ "print_format",   sys_getopt_required_argument, 0, 'P' },
+	{ "option",         sys_getopt_required_argument, 0, 'o' },
+	{ "value",          sys_getopt_required_argument, 0, 'v' },
+	{ "level",          sys_getopt_required_argument, 0, SOCK_SHELL_OPT_SOCKET_OPTION_LEVEL },
+	{ "packet_number_prefix", sys_getopt_no_argument, 0, SOCK_SHELL_OPT_PACKET_NUMBER_PREFIX },
+	{ "rai_last",       sys_getopt_no_argument,       0, SOCK_SHELL_OPT_RAI_LAST },
+	{ "rai_no_data",    sys_getopt_no_argument,       0, SOCK_SHELL_OPT_RAI_NO_DATA },
+	{ "rai_one_resp",   sys_getopt_no_argument,       0, SOCK_SHELL_OPT_RAI_ONE_RESP },
+	{ "rai_ongoing",    sys_getopt_no_argument,       0, SOCK_SHELL_OPT_RAI_ONGOING },
+	{ "rai_wait_more",  sys_getopt_no_argument,       0, SOCK_SHELL_OPT_RAI_WAIT_MORE },
+	{ "help",           sys_getopt_no_argument,       0, 'h' },
+	{ 0,                0,                            0, 0   }
 };
 
 static const char short_options[] = "i:I:a:p:f:t:b:ST:cV:H:C:F:d:l:e:s:xrB:WKP:o:v:h";
@@ -342,56 +342,56 @@ static int cmd_sock_getaddrinfo(const struct shell *shell, size_t argc, char **a
 
 	memset(arg_hostname, 0, SOCK_MAX_ADDR_LEN + 1);
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		int addr_len = 0;
 
 		switch (opt) {
 		case 'H': /* Hostname */
-			addr_len = strlen(optarg);
+			addr_len = strlen(sys_getopt_optarg);
 			if (addr_len > SOCK_MAX_ADDR_LEN) {
 				mosh_error(
 					"Hostname length %d exceeded. Maximum is %d.",
 					addr_len, SOCK_MAX_ADDR_LEN);
 				return -EINVAL;
 			}
-			memcpy(arg_hostname, optarg, addr_len);
+			memcpy(arg_hostname, sys_getopt_optarg, addr_len);
 			break;
 		case 'f': /* Address family */
-			if (strcmp(optarg, "unspec") == 0) {
+			if (strcmp(sys_getopt_optarg, "unspec") == 0) {
 				arg_family = AF_UNSPEC;
-			} else if (strcmp(optarg, "inet") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "inet") == 0) {
 				arg_family = AF_INET;
-			} else if (!strcmp(optarg, "inet6")) {
+			} else if (!strcmp(sys_getopt_optarg, "inet6")) {
 				arg_family = AF_INET6;
 			} else {
 				mosh_error(
 					"Unsupported address family=%s. Supported values are: "
 					"'unspec', 'inet' (ipv4) or 'inet6' (ipv6)",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
 		case 't': /* Socket type */
-			if (strcmp(optarg, "any") == 0) {
+			if (strcmp(sys_getopt_optarg, "any") == 0) {
 				arg_type = 0;
-			} else if (strcmp(optarg, "stream") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "stream") == 0) {
 				arg_type = SOCK_STREAM;
-			} else if (strcmp(optarg, "dgram") == 0) {
+			} else if (strcmp(sys_getopt_optarg, "dgram") == 0) {
 				arg_type = SOCK_DGRAM;
 			} else {
 				mosh_error(
 					"Unsupported address type=%s. Supported values are: "
 					"'any', 'stream' (tcp) or 'dgram' (udp)",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
 		case 'I': /* PDN CID */
-			arg_pdn_cid = atoi(optarg);
+			arg_pdn_cid = atoi(sys_getopt_optarg);
 			if (arg_pdn_cid < 0) {
 				mosh_error(
 					"PDN CID (%d) must be non-negative integer.",
@@ -403,12 +403,12 @@ static int cmd_sock_getaddrinfo(const struct shell *shell, size_t argc, char **a
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -449,16 +449,16 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 	memset(arg_address, 0, SOCK_MAX_ADDR_LEN + 1);
 	memset(arg_peer_hostname, 0, SOCK_MAX_ADDR_LEN + 1);
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		int addr_len = 0;
 
 		switch (opt) {
 		case 'I': /* PDN CID */
-			arg_pdn_cid = atoi(optarg);
+			arg_pdn_cid = atoi(sys_getopt_optarg);
 			if (arg_pdn_cid < 0) {
 				mosh_error(
 					"PDN CID (%d) must be non-negative integer.",
@@ -467,17 +467,17 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'a': /* IP address, or hostname */
-			addr_len = strlen(optarg);
+			addr_len = strlen(sys_getopt_optarg);
 			if (addr_len > SOCK_MAX_ADDR_LEN) {
 				mosh_error(
 					"Address length %d exceeded. Maximum is %d.",
 					addr_len, SOCK_MAX_ADDR_LEN);
 				return -EINVAL;
 			}
-			memcpy(arg_address, optarg, addr_len);
+			memcpy(arg_address, sys_getopt_optarg, addr_len);
 			break;
 		case 'p': /* Port */
-			arg_port = atoi(optarg);
+			arg_port = atoi(sys_getopt_optarg);
 			if (arg_port <= 0 || arg_port > 65535) {
 				mosh_error(
 					"Port (%d) must be bigger than 0 and smaller than 65536.",
@@ -486,37 +486,37 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'f': /* Address family */
-			if (!strcmp(optarg, "inet")) {
+			if (!strcmp(sys_getopt_optarg, "inet")) {
 				arg_family = AF_INET;
-			} else if (!strcmp(optarg, "inet6")) {
+			} else if (!strcmp(sys_getopt_optarg, "inet6")) {
 				arg_family = AF_INET6;
-			} else if (!strcmp(optarg, "packet")) {
+			} else if (!strcmp(sys_getopt_optarg, "packet")) {
 				arg_family = AF_PACKET;
 			} else {
 				mosh_error(
 					"Unsupported address family=%s. Supported values are: "
 					"'inet' (ipv4, default), 'inet6' (ipv6) or 'packet'",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
 		case 't': /* Socket type */
-			if (!strcmp(optarg, "stream")) {
+			if (!strcmp(sys_getopt_optarg, "stream")) {
 				arg_type = SOCK_STREAM;
-			} else if (!strcmp(optarg, "dgram")) {
+			} else if (!strcmp(sys_getopt_optarg, "dgram")) {
 				arg_type = SOCK_DGRAM;
-			} else if (!strcmp(optarg, "raw")) {
+			} else if (!strcmp(sys_getopt_optarg, "raw")) {
 				arg_type = SOCK_RAW;
 			} else {
 				mosh_error(
 					"Unsupported address type=%s. Supported values are: "
 					"'stream' (tcp, default), 'dgram' (udp) or 'raw'",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
 		case 'b': /* Bind port */
-			arg_bind_port = atoi(optarg);
+			arg_bind_port = atoi(sys_getopt_optarg);
 			if (arg_bind_port <= 0 || arg_bind_port > 65535) {
 				mosh_error(
 					"Bind port (%d) must be bigger than 0 and "
@@ -533,11 +533,11 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			break;
 		case 'T': /* Security tag */
 			err = 0;
-			arg_sec_tag = shell_strtoul(optarg, 10, &err);
+			arg_sec_tag = shell_strtoul(sys_getopt_optarg, 10, &err);
 			if (err) {
 				mosh_error(
 					"Valid range for security tag (%s) is 0 .. %u.",
-					optarg, UINT32_MAX);
+					sys_getopt_optarg, UINT32_MAX);
 				return -EINVAL;
 			}
 			break;
@@ -545,7 +545,7 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			arg_session_cache = true;
 			break;
 		case 'V': /* TLS peer verify */
-			arg_peer_verify = atoi(optarg);
+			arg_peer_verify = atoi(sys_getopt_optarg);
 			if (arg_peer_verify < 0 || arg_peer_verify > 2) {
 				mosh_error(
 					"Valid values for peer verify (%d) are 0, 1 and 2.",
@@ -554,17 +554,17 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'H': /* TLS peer hostname */
-			addr_len = strlen(optarg);
+			addr_len = strlen(sys_getopt_optarg);
 			if (addr_len > SOCK_MAX_ADDR_LEN) {
 				mosh_error(
 					"Peer hostname length %d exceeded. Maximum is %d.",
 					addr_len, SOCK_MAX_ADDR_LEN);
 				return -EINVAL;
 			}
-			strcpy(arg_peer_hostname, optarg);
+			strcpy(arg_peer_hostname, sys_getopt_optarg);
 			break;
 		case 'C': /* DTLS CID setting */
-			arg_dtls_cid = atoi(optarg);
+			arg_dtls_cid = atoi(sys_getopt_optarg);
 			if (arg_dtls_cid < 0 || arg_dtls_cid > 2) {
 				mosh_error(
 					"Valid values for DTLS CID setting (%d) are 0, 1 and 2.",
@@ -573,7 +573,7 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			}
 			break;
 		case 'F': /* DTLS fragmentation extension */
-			arg_dtls_frag_ext = atoi(optarg);
+			arg_dtls_frag_ext = atoi(sys_getopt_optarg);
 			if (arg_dtls_frag_ext < 0 || arg_dtls_frag_ext > 2) {
 				mosh_error(
 					"Valid values for DTLS fragmentation extension (%d) are "
@@ -585,12 +585,12 @@ static int cmd_sock_connect(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -629,27 +629,27 @@ static int cmd_sock_close(const struct shell *shell, size_t argc, char **argv)
 	/* Variables for command line arguments */
 	int arg_socket_id = SOCK_ID_NONE;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "i:h", long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "i:h", long_options, NULL)) != -1) {
 
 		switch (opt) {
 		case 'i': /* Socket ID */
-			arg_socket_id = atoi(optarg);
+			arg_socket_id = atoi(sys_getopt_optarg);
 			break;
 
 		case 'h':
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -685,39 +685,39 @@ static int cmd_sock_send(const struct shell *shell, size_t argc, char **argv)
 
 	memset(arg_send_data, 0, SOCK_MAX_SEND_DATA_LEN + 1);
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 		int send_data_len = 0;
 
 		switch (opt) {
 		case 'i': /* Socket ID */
-			arg_socket_id = atoi(optarg);
+			arg_socket_id = atoi(sys_getopt_optarg);
 			break;
 		case 'd': /* Data to be sent is available in send buffer */
-			send_data_len = strlen(optarg);
+			send_data_len = strlen(sys_getopt_optarg);
 			if (send_data_len > SOCK_MAX_SEND_DATA_LEN) {
 				mosh_error(
 					"Data length %d exceeded. Maximum is %d. Given data: %s",
 					send_data_len, SOCK_MAX_SEND_DATA_LEN,
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
-			strcpy(arg_send_data, optarg);
+			strcpy(arg_send_data, sys_getopt_optarg);
 			break;
 		case 'x': /* Send data string is defined in hex format */
 			arg_data_format_hex = true;
 			break;
 		case 'l': /* Length of data */
-			arg_data_length = atoi(optarg);
+			arg_data_length = atoi(sys_getopt_optarg);
 			break;
 		case 'e': /* Interval in which data will be sent */
-			arg_data_interval = atoi(optarg);
+			arg_data_interval = atoi(sys_getopt_optarg);
 			break;
 		case 's': /* Buffer size */
-			arg_buffer_size = atoi(optarg);
+			arg_buffer_size = atoi(sys_getopt_optarg);
 			if (arg_buffer_size <= 0) {
 				mosh_error(
 					"Buffer size %d must be a positive number",
@@ -727,12 +727,12 @@ static int cmd_sock_send(const struct shell *shell, size_t argc, char **argv)
 			break;
 		case 'B': /* Blocking/non-blocking send or receive */
 		{
-			int blocking = atoi(optarg);
+			int blocking = atoi(sys_getopt_optarg);
 
 			if (blocking != 0 && blocking != 1) {
 				mosh_error(
 					"Blocking (%s) must be either '0' (false) or '1' (true)",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			arg_blocking_recv = blocking;
@@ -750,12 +750,12 @@ static int cmd_sock_send(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -794,30 +794,30 @@ static int cmd_sock_recv(const struct shell *shell, size_t argc, char **argv)
 	bool arg_blocking_recv = false;
 	enum sock_recv_print_format arg_recv_print_format = SOCK_RECV_PRINT_FORMAT_NONE;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 
 		switch (opt) {
 		case 'i': /* Socket ID */
-			arg_socket_id = atoi(optarg);
+			arg_socket_id = atoi(sys_getopt_optarg);
 			break;
 		case 'l': /* Length of data */
-			arg_data_length = atoi(optarg);
+			arg_data_length = atoi(sys_getopt_optarg);
 			break;
 		case 'r': /* Start monitoring received data */
 			arg_receive_start = true;
 			break;
 		case 'B': /* Blocking/non-blocking send or receive */
 		{
-			int blocking = atoi(optarg);
+			int blocking = atoi(sys_getopt_optarg);
 
 			if (blocking != 0 && blocking != 1) {
 				mosh_error(
 					"Blocking (%s) must be either '0' (false) or '1' (true)",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			arg_blocking_recv = blocking;
@@ -825,16 +825,16 @@ static int cmd_sock_recv(const struct shell *shell, size_t argc, char **argv)
 			break;
 		}
 		case 'P': /* Receive data print format: "str" or "hex" */
-			if (!strcmp(optarg, "str")) {
+			if (!strcmp(sys_getopt_optarg, "str")) {
 				arg_recv_print_format =
 					SOCK_RECV_PRINT_FORMAT_STR;
-			} else if (!strcmp(optarg, "hex")) {
+			} else if (!strcmp(sys_getopt_optarg, "hex")) {
 				arg_recv_print_format =
 					SOCK_RECV_PRINT_FORMAT_HEX;
 			} else {
 				mosh_error(
 					"Receive data print format (%s) must be 'str' or 'hex'",
-					optarg);
+					sys_getopt_optarg);
 				return -EINVAL;
 			}
 			break;
@@ -843,12 +843,12 @@ static int cmd_sock_recv(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -884,15 +884,15 @@ static int cmd_sock_rai(const struct shell *shell, size_t argc, char **argv)
 	bool arg_rai_wait_more = false;
 	int rai_option_count = 0;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 
 		switch (opt) {
 		case 'i': /* Socket ID */
-			arg_socket_id = atoi(optarg);
+			arg_socket_id = atoi(sys_getopt_optarg);
 			break;
 
 		case SOCK_SHELL_OPT_RAI_LAST:
@@ -920,12 +920,12 @@ static int cmd_sock_rai(const struct shell *shell, size_t argc, char **argv)
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}
@@ -1064,23 +1064,23 @@ static int cmd_sock_setgetopt(const struct shell *shell, size_t argc, char **arg
 	struct sock_opt_entry *sock_opt;
 	struct sock_level_entry *sock_level;
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, short_options, long_options, NULL)) != -1) {
 
 		switch (opt) {
 		case 'i': /* Socket ID */
-			arg_socket_id = atoi(optarg);
+			arg_socket_id = atoi(sys_getopt_optarg);
 			break;
 
 		case SOCK_SHELL_OPT_SOCKET_OPTION_LEVEL: /* Level */
-			arg_sock_opt_level = atoi(optarg);
-			if (arg_sock_opt_level == 0 && strcmp(optarg, "0") != 0) {
-				sock_level = sock_level_map(optarg);
+			arg_sock_opt_level = atoi(sys_getopt_optarg);
+			if (arg_sock_opt_level == 0 && strcmp(sys_getopt_optarg, "0") != 0) {
+				sock_level = sock_level_map(sys_getopt_optarg);
 				if (sock_level == NULL) {
-					mosh_error("Unknown socket level: %s", optarg);
+					mosh_error("Unknown socket level: %s", sys_getopt_optarg);
 					goto show_usage;
 				}
 				arg_sock_opt_level = sock_level->level;
@@ -1088,11 +1088,11 @@ static int cmd_sock_setgetopt(const struct shell *shell, size_t argc, char **arg
 			break;
 
 		case 'o': /* Option */
-			arg_sock_opt_id = atoi(optarg);
+			arg_sock_opt_id = atoi(sys_getopt_optarg);
 			if (arg_sock_opt_id == 0) {
-				sock_opt = sock_opt_map(optarg);
+				sock_opt = sock_opt_map(sys_getopt_optarg);
 				if (sock_opt == NULL) {
-					mosh_error("Unknown socket option: %s", optarg);
+					mosh_error("Unknown socket option: %s", sys_getopt_optarg);
 					goto show_usage;
 				}
 				arg_sock_opt_id = sock_opt->opt;
@@ -1104,22 +1104,22 @@ static int cmd_sock_setgetopt(const struct shell *shell, size_t argc, char **arg
 
 		case 'v': /* Value */
 			if (cmd == SOCKOPT_CMD_TYPE_GET) {
-				mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+				mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 				goto show_usage;
 			}
-			arg_sock_opt_value = optarg;
+			arg_sock_opt_value = sys_getopt_optarg;
 			break;
 
 		case 'h':
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}

--- a/samples/cellular/modem_shell/src/startup_cmd/startup_cmd_shell.c
+++ b/samples/cellular/modem_shell/src/startup_cmd/startup_cmd_shell.c
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>
-#include <unistd.h>
-#include <getopt.h>
+#include <zephyr/sys/sys_getopt.h>
 
 #include "mosh_print.h"
 #include "startup_cmd_settings.h"
@@ -40,12 +41,12 @@ enum {
 };
 
 /* Specifying the expected options (both long and short) */
-static struct option long_options[] = {
-	{ "read", no_argument, 0, 'r' },
-	{ "time", required_argument, 0, 't' },
-	{ "mem1", required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_1 },
-	{ "mem2", required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_2 },
-	{ "mem3", required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_3 },
+static struct sys_getopt_option long_options[] = {
+	{ "read", sys_getopt_no_argument, 0, 'r' },
+	{ "time", sys_getopt_required_argument, 0, 't' },
+	{ "mem1", sys_getopt_required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_1 },
+	{ "mem2", sys_getopt_required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_2 },
+	{ "mem3", sys_getopt_required_argument, 0, SETT_CMD_SHELL_OPT_MEM_SLOT_3 },
 	{ 0, 0, 0, 0 }
 };
 
@@ -67,29 +68,29 @@ static int startup_cmd_shell(const struct shell *shell, size_t argc, char **argv
 		goto show_usage;
 	}
 
-	optreset = 1;
-	optind = 1;
+	sys_getopt_init();
+
 	int opt;
 
-	while ((opt = getopt_long(argc, argv, "t:rh", long_options, NULL)) != -1) {
+	while ((opt = sys_getopt_long(argc, argv, "t:rh", long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'r':
 			common_option = SETT_CMD_COMMON_READ;
 			break;
 		case 't':
-			starttime = atoi(optarg);
+			starttime = atoi(sys_getopt_optarg);
 			starttime_given = true;
 			break;
 		case SETT_CMD_SHELL_OPT_MEM_SLOT_1:
-			startup_cmd_str = optarg;
+			startup_cmd_str = sys_getopt_optarg;
 			startup_cmd_mem_slot = 1;
 			break;
 		case SETT_CMD_SHELL_OPT_MEM_SLOT_2:
-			startup_cmd_str = optarg;
+			startup_cmd_str = sys_getopt_optarg;
 			startup_cmd_mem_slot = 2;
 			break;
 		case SETT_CMD_SHELL_OPT_MEM_SLOT_3:
-			startup_cmd_str = optarg;
+			startup_cmd_str = sys_getopt_optarg;
 			startup_cmd_mem_slot = 3;
 			break;
 
@@ -97,12 +98,12 @@ static int startup_cmd_shell(const struct shell *shell, size_t argc, char **argv
 			goto show_usage;
 		case '?':
 		default:
-			mosh_error("Unknown option (%s). See usage:", argv[optind - 1]);
+			mosh_error("Unknown option (%s). See usage:", argv[sys_getopt_optind - 1]);
 			goto show_usage;
 		}
 	}
 
-	if (optind < argc) {
+	if (sys_getopt_optind < argc) {
 		mosh_error("Arguments without '-' not supported: %s", argv[argc - 1]);
 		goto show_usage;
 	}

--- a/samples/cellular/modem_shell/src/utils/mosh_print.c
+++ b/samples/cellular/modem_shell/src/utils/mosh_print.c
@@ -7,10 +7,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <assert.h>
 
 #include <zephyr/kernel.h>
-#include <zephyr/posix/time.h>
 #include <zephyr/sys/cbprintf.h>
 #include <zephyr/shell/shell.h>
 #include <modem/modem_info.h>

--- a/samples/crypto/psa_tls/include/certificate.h
+++ b/samples/crypto/psa_tls/include/certificate.h
@@ -11,16 +11,15 @@
 #define SERVER_CERTIFICATE_TAG 2
 #define PSK_TAG 3
 
-
 static const unsigned char ca_certificate[] = {
-#include "root-cert.der.inc"
+#include <root-cert.der.inc>
 };
 static const unsigned char server_certificate[] = {
-#include "server-cert.der.inc"
+#include <server-cert.der.inc>
 };
 /* This is the private key in pkcs#8 format. */
 static const unsigned char private_key[] = {
-#include "server-cert-key.der.inc"
+#include <server-cert-key.der.inc>
 };
 
 #endif /* __CERTIFICATE_H__ */

--- a/samples/crypto/psa_tls/src/main.c
+++ b/samples/crypto/psa_tls/src/main.c
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrfx.h>
-#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/tls_credentials.h>
-#include "psa_tls_functions.h"
-#include "psa_tls_credentials.h"
-#include "certificate.h"
-#include "dummy_psk.h"
-#include "psa/crypto.h"
+
+#include <psa/crypto.h>
+
+#include <psa_tls_functions.h>
+#include <psa_tls_credentials.h>
+#include <certificate.h>
+#include <dummy_psk.h>
 
 LOG_MODULE_REGISTER(psa_tls_sample);
-
 
 static int tls_set_preshared_key(void)
 {
@@ -36,7 +35,6 @@ static int tls_set_preshared_key(void)
 
 	return APP_SUCCESS;
 }
-
 
 int main(void)
 {

--- a/samples/crypto/psa_tls/src/non-secure/psa_tls_credentials_client.c
+++ b/samples/crypto/psa_tls/src/non-secure/psa_tls_credentials_client.c
@@ -5,25 +5,16 @@
  */
 
 #include <zephyr/logging/log.h>
+#include <zephyr/net/tls_credentials.h>
+
+#include <psa/protected_storage.h>
+
+#include <certificate.h>
+#include <psa_tls_credentials.h>
+
 LOG_MODULE_REGISTER(psa_tls_credentials_client_non_secure);
 
-#include <nrfx.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/net_core.h>
-#include <zephyr/net/tls_credentials.h>
-#include <zephyr/linker/sections.h>
-
-#include "certificate.h"
-#include "psa_tls_credentials.h"
-
-#include <tfm_ns_interface.h>
-#include <psa/storage_common.h>
-#include "psa/protected_storage.h"
-
 static unsigned char ca_cert_buf[sizeof(ca_certificate)];
-
 
 /** @brief Function for storing the CA certificate in Protected Storage.
  */

--- a/samples/crypto/psa_tls/src/non-secure/psa_tls_credentials_server.c
+++ b/samples/crypto/psa_tls/src/non-secure/psa_tls_credentials_server.c
@@ -5,26 +5,17 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(psa_tls_credentials_server_non_secure);
-
-#include <nrfx.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/net_core.h>
 #include <zephyr/net/tls_credentials.h>
-#include <zephyr/linker/sections.h>
 
-#include "certificate.h"
-#include "psa_tls_credentials.h"
+#include <psa/protected_storage.h>
 
-#include <tfm_ns_interface.h>
-#include <psa/storage_common.h>
-#include "psa/protected_storage.h"
+#include <certificate.h>
+#include <psa_tls_credentials.h>
+
+LOG_MODULE_REGISTER(psa_tls_credentials_server_non_secure);
 
 static unsigned char server_cert_buf[sizeof(server_certificate)];
 static unsigned char private_key_buf[sizeof(private_key)];
-
 
 /** @brief Function for storing server certificate and server private key
  *  in Protected Storage.

--- a/samples/crypto/psa_tls/src/psa_dtls_functions_client.c
+++ b/samples/crypto/psa_tls/src/psa_dtls_functions_client.c
@@ -4,20 +4,19 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(psa_dtls_client);
-
-#include <nrfx.h>
+#include <arpa/inet.h>
 #include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/net_core.h>
-#include <zephyr/net/tls_credentials.h>
-#include <zephyr/linker/sections.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
-#include "certificate.h"
-#include "psa_tls_functions.h"
-#include "psa_tls_credentials.h"
+#include <zephyr/logging/log.h>
+#include <zephyr/net/tls_credentials.h>
+
+#include <certificate.h>
+#include <psa_tls_functions.h>
+#include <psa_tls_credentials.h>
+
+LOG_MODULE_REGISTER(psa_dtls_client);
 
 static char recv_buffer[RECV_BUFFER_SIZE]; /* Buffer for storing payload */
 

--- a/samples/crypto/psa_tls/src/psa_dtls_functions_server.c
+++ b/samples/crypto/psa_tls/src/psa_dtls_functions_server.c
@@ -4,20 +4,18 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(psa_dtls_server);
-
-#include <nrfx.h>
 #include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/net_core.h>
-#include <zephyr/net/tls_credentials.h>
-#include <zephyr/linker/sections.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
-#include "certificate.h"
-#include "psa_tls_functions.h"
-#include "psa_tls_credentials.h"
+#include <zephyr/logging/log.h>
+#include <zephyr/net/tls_credentials.h>
+
+#include <certificate.h>
+#include <psa_tls_functions.h>
+#include <psa_tls_credentials.h>
+
+LOG_MODULE_REGISTER(psa_dtls_server);
 
 static char recv_buffer[RECV_BUFFER_SIZE]; /* Buffer for storing payload */
 

--- a/samples/crypto/psa_tls/src/psa_tls_common.c
+++ b/samples/crypto/psa_tls/src/psa_tls_common.c
@@ -4,10 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <nrfx.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
+#include <sys/socket.h>
 
 /** @brief Function for sending all data in a given buffer to a connected
  * socket.

--- a/samples/crypto/psa_tls/src/psa_tls_functions_client.c
+++ b/samples/crypto/psa_tls/src/psa_tls_functions_client.c
@@ -7,11 +7,10 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(psa_tls_client);
 
-#include <nrfx.h>
+#include <arpa/inet.h>
 #include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/net_core.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/linker/sections.h>
 

--- a/samples/crypto/psa_tls/src/psa_tls_functions_client.c
+++ b/samples/crypto/psa_tls/src/psa_tls_functions_client.c
@@ -4,22 +4,21 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-#include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(psa_tls_client);
-
 #include <arpa/inet.h>
 #include <errno.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#include <zephyr/net/tls_credentials.h>
-#include <zephyr/linker/sections.h>
 
-#include "certificate.h"
-#include "psa_tls_functions.h"
-#include "psa_tls_credentials.h"
+#include <zephyr/logging/log.h>
+#include <zephyr/net/tls_credentials.h>
+
+#include <certificate.h>
+#include <psa_tls_functions.h>
+#include <psa_tls_credentials.h>
+
+LOG_MODULE_REGISTER(psa_tls_client);
 
 static char recv_buffer[RECV_BUFFER_SIZE]; /* Buffer for storing payload */
-
 
 /** @brief Function for setting up the client socket to use for TLS handshake.
  *

--- a/samples/crypto/psa_tls/src/psa_tls_functions_server.c
+++ b/samples/crypto/psa_tls/src/psa_tls_functions_server.c
@@ -4,23 +4,20 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
+#include <errno.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <zephyr/logging/log.h>
+#include <zephyr/net/tls_credentials.h>
+
+#include <certificate.h>
+#include <psa_tls_functions.h>
+#include <psa_tls_credentials.h>
+
 LOG_MODULE_REGISTER(psa_tls_server);
 
-#include <nrfx.h>
-#include <errno.h>
-#include <zephyr/kernel.h>
-#include <zephyr/net/socket.h>
-#include <zephyr/net/net_core.h>
-#include <zephyr/net/tls_credentials.h>
-#include <zephyr/linker/sections.h>
-
-#include "certificate.h"
-#include "psa_tls_functions.h"
-#include "psa_tls_credentials.h"
-
 static char recv_buffer[RECV_BUFFER_SIZE]; /* Buffer for storing payload */
-
 
 /** @brief Function for setting up the server socket to use for TLS handshake.
  *

--- a/samples/crypto/psa_tls/src/secure/psa_tls_credentials_client.c
+++ b/samples/crypto/psa_tls/src/secure/psa_tls_credentials_client.c
@@ -5,15 +5,12 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(psa_tls_credentials_client_secure);
-
-#include <nrfx.h>
-#include <zephyr/kernel.h>
-#include <zephyr/linker/sections.h>
 #include <zephyr/net/tls_credentials.h>
-#include "psa_tls_credentials.h"
-#include "certificate.h"
 
+#include <psa_tls_credentials.h>
+#include <certificate.h>
+
+LOG_MODULE_REGISTER(psa_tls_credentials_client_secure);
 
 /** @brief Function for registering the CA certificate for the TLS handshake.
  */

--- a/samples/crypto/psa_tls/src/secure/psa_tls_credentials_server.c
+++ b/samples/crypto/psa_tls/src/secure/psa_tls_credentials_server.c
@@ -5,15 +5,12 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(psa_tls_credentials_server_secure);
-
-#include <nrfx.h>
-#include <zephyr/kernel.h>
-#include <zephyr/linker/sections.h>
 #include <zephyr/net/tls_credentials.h>
-#include "psa_tls_credentials.h"
-#include "certificate.h"
 
+#include <psa_tls_credentials.h>
+#include <certificate.h>
+
+LOG_MODULE_REGISTER(psa_tls_credentials_server_secure);
 
 /** @brief Function for registering the server certificate and
  * server private key for the TLS handshake.

--- a/samples/dect/dect_phy/dect_shell/src/utils/desh_print.c
+++ b/samples/dect/dect_phy/dect_shell/src/utils/desh_print.c
@@ -7,10 +7,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <assert.h>
 
 #include <zephyr/kernel.h>
-#include <zephyr/posix/time.h>
 #include <zephyr/sys/cbprintf.h>
 #include <zephyr/shell/shell.h>
 #include <modem/modem_info.h>

--- a/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
+++ b/subsys/net/lib/nrf_provisioning/src/nrf_provisioning_http.c
@@ -219,7 +219,7 @@ static void init_rest_client_request(struct nrf_provisioning_http_context const 
 
 	req->host = CONFIG_NRF_PROVISIONING_HTTP_HOSTNAME;
 	req->port = CONFIG_NRF_PROVISIONING_HTTP_PORT;
-	req->tls_peer_verify = TLS_PEER_VERIFY_REQUIRED;
+	req->tls_peer_verify = ZSOCK_TLS_PEER_VERIFY_REQUIRED;
 	req->sec_tag = CONFIG_NRF_PROVISIONING_ROOT_CA_SEC_TAG;
 	req->timeout_ms = CONFIG_NRF_PROVISIONING_HTTP_TIMEOUT_MS;
 

--- a/tests/benchmarks/multicore/idle_spim/src/main.c
+++ b/tests/benchmarks/multicore/idle_spim/src/main.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(idle_spim);
 #define SPI_READ_COUNT		 50
 
 static struct spi_dt_spec spim_spec =
-	SPI_DT_SPEC_GET(DT_NODELABEL(bmi270), SPI_OP_MODE_MASTER | SPI_MODE, 0);
+	SPI_DT_SPEC_GET(DT_NODELABEL(bmi270), SPI_OP_MODE_MASTER | SPI_MODE);
 
 void spi_read_register(uint8_t register_address, uint8_t *register_value)
 {

--- a/tests/benchmarks/multicore/idle_spim_loopback/src/main.c
+++ b/tests/benchmarks/multicore/idle_spim_loopback/src/main.c
@@ -51,7 +51,7 @@ static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led), gpios);
 #endif
 #endif
 
-static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE, 0);
+static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE);
 
 static const struct gpio_dt_spec pin_in = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), test_gpios);
 

--- a/tests/benchmarks/power_consumption/spi/src/driver_test.c
+++ b/tests/benchmarks/power_consumption/spi/src/driver_test.c
@@ -26,7 +26,7 @@ bool self_suspend_req(void)
 void thread_definition(void)
 {
 	int ret;
-	struct spi_dt_spec spispec = SPI_DT_SPEC_GET(DT_ALIAS(accel0), SPIOP, 0);
+	struct spi_dt_spec spispec = SPI_DT_SPEC_GET(DT_ALIAS(accel0), SPIOP);
 
 	uint8_t tx_buffer[5] = {READ_COMMAND, DEVID_AD_ADDRESS, 0xFF, 0xFF, 0xFF};
 	uint8_t rx_buffer[5] = {0, 0, 0, 0, 0};

--- a/tests/benchmarks/spi_endless/src/main.c
+++ b/tests/benchmarks/spi_endless/src/main.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 #define	DELTA			(1)
 
 #if CONFIG_ROLE_HOST == 1
-static struct spi_dt_spec spim = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPIM_OP, 0);
+static struct spi_dt_spec spim = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPIM_OP);
 #else
 static const struct device *spis_dev = DEVICE_DT_GET(DT_NODELABEL(dut_spis));
 static const struct spi_config spis_config = {

--- a/tests/drivers/spi/spi_latency/src/main.c
+++ b/tests/drivers/spi/spi_latency/src/main.c
@@ -22,7 +22,7 @@
 
 #define MAX_TEST_BUFFER_SIZE 2000
 
-static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi), SPI_MODE, 0);
+static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi), SPI_MODE);
 const struct device *const tst_timer_dev = DEVICE_DT_GET(DT_ALIAS(tst_timer));
 
 #define MEMORY_SECTION(node)                                                                       \

--- a/tests/drivers/spi/spim_clock_control/src/main.c
+++ b/tests/drivers/spi/spim_clock_control/src/main.c
@@ -18,7 +18,7 @@
 #define TEST_BUFFER_SIZE	     512
 #define REQUEST_SERVING_WAIT_TIME_US 10000
 
-static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE, 0);
+static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE);
 const struct device *const fll16m_dev = DEVICE_DT_GET(DT_NODELABEL(fll16m));
 
 #define MEMORY_SECTION(node)                                                                       \

--- a/tests/drivers/spi/spim_mosi_toggles/src/main.c
+++ b/tests/drivers/spi/spim_mosi_toggles/src/main.c
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(spim_mosi_toggles, LOG_LEVEL_INF);
 
 #define SPI_MODE (SPI_OP_MODE_MASTER | SPI_WORD_SET(8) | SPI_LINES_SINGLE | SPI_TRANSFER_MSB)
 
-static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE, 0);
+static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE);
 
 #define MEMORY_SECTION(node)                                                                       \
 	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \

--- a/tests/drivers/spi/spim_pan/src/main.c
+++ b/tests/drivers/spi/spim_pan/src/main.c
@@ -31,7 +31,7 @@
 #define TEST_BUFFER_SIZE 64
 #endif
 
-static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE, 0);
+static struct spi_dt_spec spim_spec = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPI_MODE);
 NRF_SPIM_Type *spim_reg = (NRF_SPIM_Type *)DT_REG_ADDR(DUT_SPI_NODE);
 
 static nrfx_timer_t test_timer = NRFX_TIMER_INSTANCE(DT_REG_ADDR(DT_NODELABEL(tst_timer)));

--- a/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
+++ b/tests/subsys/net/lib/nrf_provisioning/CMakeLists.txt
@@ -50,6 +50,8 @@ elseif(CONFIG_NRF_PROVISIONING_COAP)
     -DCONFIG_MODEM_INFO_BUFFER_SIZE=128
     -DCONFIG_COAP_CLIENT_MAX_REQUESTS=2
     -DCONFIG_COAP_CLIENT_BLOCK_SIZE=256
+    -DCONFIG_COAP_CLIENT_MAX_PATH_LENGTH=96
+    -DCONFIG_COAP_CLIENT_MAX_EXTRA_OPTIONS=2
   )
   cmock_handle(${ZEPHYR_BASE}/include/zephyr/net/coap_client.h)
   cmock_handle(${ZEPHYR_NRF_MODULE_DIR}/subsys/net/lib/nrf_provisioning/include/nrf_provisioning_jwt.h)

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: a1d9a8db0ea4bbee2e69feec1140e6ce20e62f5e
+      revision: pull/3678/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -144,7 +144,7 @@ manifest:
     - name: nrfxlib
       repo-path: sdk-nrfxlib
       path: nrfxlib
-      revision: 4a219034837170409e8964a120ac0ff680cfd089
+      revision: pull/1986/head
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m
@@ -156,7 +156,7 @@ manifest:
     - name: matter
       repo-path: sdk-connectedhomeip
       path: modules/lib/matter
-      revision: e0fbbd3face21c0e70acda19c56ea2ea40a59e5d
+      revision: pull/699/head
       west-commands: scripts/west/west-commands.yml
       submodules:
         - name: nlio
@@ -175,7 +175,7 @@ manifest:
     - name: nrf-802154
       repo-path: sdk-nrf-802154
       path: nrf-802154
-      revision: 69e3bfb6b806944aa76526510914ee5c1dba1ded
+      revision: pull/708/head
       groups:
         - nrf-802154
     - name: dragoon


### PR DESCRIPTION
Update coap_client function signature in nrf_provisioning client.

Zephyr codebase was changed to use ZSOCK_ and net_ prefixes
in https://github.com/zephyrproject-rtos/zephyr/commit/d45cd6716bbab3a805e3a5fd461934f0dcdc13e5
add missing prefixes.

