### PR TITLE
net: lwm2m_client_utils: Fix upmerge issues

### DIFF
--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_security.c
@@ -724,7 +724,7 @@ static int set_socketoptions(struct lwm2m_ctx *ctx)
 	if (purge_sessions) {
 		int purge = 1;
 
-		ret = zsock_setsockopt(ctx->sock_fd, SOL_TLS, NRF_SO_SEC_SESSION_CACHE_PURGE,
+		ret = zsock_setsockopt(ctx->sock_fd, ZSOCK_SOL_TLS, NRF_SO_SEC_SESSION_CACHE_PURGE,
 				       &purge, sizeof(purge));
 		if (ret) {
 			/* This is non-fatal, so just log it and continue */
@@ -737,7 +737,7 @@ static int set_socketoptions(struct lwm2m_ctx *ctx)
 		/* Modem FW 2.0.1 allows keeping the socket open while PDN is down, or modem
 		 * is in flight mode.
 		 */
-		ret = zsock_setsockopt(ctx->sock_fd, SOL_SOCKET, SO_KEEPOPEN, &(int){1},
+		ret = zsock_setsockopt(ctx->sock_fd, ZSOCK_SOL_SOCKET, SO_KEEPOPEN, &(int){1},
 				       sizeof(int));
 		if (ret) {
 			LOG_ERR("Failed to set SO_KEEPOPEN: %d", errno);

--- a/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_utils_con_management.c
+++ b/subsys/net/lib/lwm2m_client_utils/lwm2m/lwm2m_utils_con_management.c
@@ -26,7 +26,7 @@ static void lwm2m_utils_dtls_save(struct lwm2m_ctx *ctx)
 		return;
 	}
 
-	ret = zsock_setsockopt(ctx->sock_fd, SOL_TLS, TLS_DTLS_CONN_SAVE, &store_dtls,
+	ret = zsock_setsockopt(ctx->sock_fd, ZSOCK_SOL_TLS, TLS_DTLS_CONN_SAVE, &store_dtls,
 			       sizeof(store_dtls));
 	if (ret) {
 		ret = -errno;
@@ -46,7 +46,7 @@ static void lwm2m_utils_dtls_load(struct lwm2m_ctx *ctx)
 		return;
 	}
 
-	ret = zsock_setsockopt(ctx->sock_fd, SOL_TLS, TLS_DTLS_CONN_LOAD, &load_dtls,
+	ret = zsock_setsockopt(ctx->sock_fd, ZSOCK_SOL_TLS, TLS_DTLS_CONN_LOAD, &load_dtls,
 			       sizeof(load_dtls));
 	if (ret) {
 		ret = -errno;

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/con_management.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/con_management.c
@@ -53,14 +53,16 @@ static int get_lifetime_and_tau_match(const struct lwm2m_obj_path *path, uint32_
 	return 0;
 }
 
-static int setsockopt_save(int sock, int level, int optname, const void *optval, socklen_t optlen)
+static int setsockopt_save(int sock, int level, int optname, const void *optval,
+			   net_socklen_t optlen)
 {
 	zassert_equal(optname, TLS_DTLS_CONN_SAVE, "Incorrect socket option");
 
 	return 0;
 }
 
-static int setsockopt_load(int sock, int level, int optname, const void *optval, socklen_t optlen)
+static int setsockopt_load(int sock, int level, int optname, const void *optval,
+			   net_socklen_t optlen)
 {
 	zassert_equal(optname, TLS_DTLS_CONN_LOAD, "Incorrect socket option");
 

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.c
@@ -107,7 +107,7 @@ DEFINE_FAKE_VALUE_FUNC(int, at_parser_int32_get, struct at_parser *, size_t, int
 DEFINE_FAKE_VALUE_FUNC(int, at_parser_uint16_get, struct at_parser *, size_t, uint16_t *);
 DEFINE_FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_cmd_async, nrf_modem_at_resp_handler_t,
 			      const char *, ...);
-DEFINE_FAKE_VALUE_FUNC(int, z_impl_zsock_setsockopt, int, int, int, const void *, socklen_t);
+DEFINE_FAKE_VALUE_FUNC(int, z_impl_zsock_setsockopt, int, int, int, const void *, net_socklen_t);
 DEFINE_FAKE_VOID_FUNC(lwm2m_utils_rai_event_cb, struct lwm2m_ctx *, enum lwm2m_rd_client_event *);
 DEFINE_FAKE_VALUE_FUNC(uint8_t, lwm2m_firmware_get_update_state_inst, uint16_t);
 DEFINE_FAKE_VOID_FUNC(lwm2m_firmware_set_update_result_inst, uint16_t, uint8_t);

--- a/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
+++ b/tests/subsys/net/lib/lwm2m_client_utils/src/stubs.h
@@ -101,7 +101,7 @@ DECLARE_FAKE_VALUE_FUNC(int, at_parser_int32_get, struct at_parser *, size_t, in
 DECLARE_FAKE_VALUE_FUNC(int, at_parser_uint16_get, struct at_parser *, size_t, uint16_t *);
 DECLARE_FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_cmd_async, nrf_modem_at_resp_handler_t,
 			       const char *, ...);
-DECLARE_FAKE_VALUE_FUNC(int, z_impl_zsock_setsockopt, int, int, int, const void *, socklen_t);
+DECLARE_FAKE_VALUE_FUNC(int, z_impl_zsock_setsockopt, int, int, int, const void *, net_socklen_t);
 DECLARE_FAKE_VOID_FUNC(lwm2m_utils_rai_event_cb, struct lwm2m_ctx *, enum lwm2m_rd_client_event *);
 DECLARE_FAKE_VALUE_FUNC(uint8_t, lwm2m_firmware_get_update_state_inst, uint16_t);
 DECLARE_FAKE_VOID_FUNC(lwm2m_firmware_set_update_result_inst, uint16_t, uint8_t);


### PR DESCRIPTION
Zephyr codebase was changed to use ZSOCK_ and net_ prefixes
in https://github.com/zephyrproject-rtos/zephyr/commit/d45cd6716bbab3a805e3a5fd461934f0dcdc13e5
add missing prefixes.
