### PR TITLE
tests: lib: location: Fix cmock generation

### DIFF
--- a/tests/lib/location/CMakeLists.txt
+++ b/tests/lib/location/CMakeLists.txt
@@ -36,6 +36,7 @@ cmock_handle(${ZEPHYR_BASE}/include/zephyr/net/net_if.h
   FUNC_EXCLUDE ".*net_if_queue_tx"
   FUNC_EXCLUDE ".*net_if_try_queue_tx"
   FUNC_EXCLUDE ".*net_if_register_timestamp_cb"
+  FUNC_EXCLUDE ".*net_if_unregister_timestamp_cb"
   FUNC_EXCLUDE ".*net_if_call_timestamp_cb"
   FUNC_EXCLUDE ".*net_if_add_tx_timestamp"
   FUNC_EXCLUDE ".*net_if_ipv4_get_netmask"


### PR DESCRIPTION
Excluded net_if_unregister_timestamp_cb from net_if cmock generation.