### PR TITLE
dts: radio_fem: generic-fem-two-ctrl-pins was renamed

### DIFF
--- a/doc/nrf/app_dev/device_guides/fem/fem_simple_gpio.rst
+++ b/doc/nrf/app_dev/device_guides/fem/fem_simple_gpio.rst
@@ -29,7 +29,7 @@ To use the Simple GPIO implementation of FEM with SKY66112-11, complete the foll
 
       / {
          nrf_radio_fem: name_of_fem_node {
-            compatible = "skyworks,sky66112-11", "generic-fem-two-ctrl-pins";
+            compatible = "skyworks,sky66112-11", "radio-fem-two-ctrl-pins";
             ctx-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
             crx-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
          };

--- a/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66112-11.yaml
@@ -8,7 +8,7 @@ description: |
 
 compatible: "skyworks,sky66112-11"
 
-include: generic-fem-two-ctrl-pins.yaml
+include: radio-fem-two-ctrl-pins.yaml
 
 properties:
     ctx-settle-time-us:

--- a/dts/bindings/radio_fem/skyworks,sky66114-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66114-11.yaml
@@ -7,7 +7,7 @@ description: |
     gain values appropriate for SKY66114-11 device.
 
 include:
-  - name: generic-fem-two-ctrl-pins.yaml
+  - name: radio-fem-two-ctrl-pins.yaml
   - name: skyworks,sky66112-11.yaml
     property-blocklist:
       - ant-sel-gpios

--- a/dts/bindings/radio_fem/skyworks,sky66403-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66403-11.yaml
@@ -7,7 +7,7 @@ description: |
     gain values appropriate for SKY66403-11 device.
 
 include:
-  - name: generic-fem-two-ctrl-pins.yaml
+  - name: radio-fem-two-ctrl-pins.yaml
   - name: skyworks,sky66112-11.yaml
 
 compatible: "skyworks,sky66403-11"

--- a/dts/bindings/radio_fem/skyworks,sky66407-11.yaml
+++ b/dts/bindings/radio_fem/skyworks,sky66407-11.yaml
@@ -8,7 +8,7 @@ description: |
 
 compatible: "skyworks,sky66407-11"
 
-include: generic-fem-two-ctrl-pins.yaml
+include: radio-fem-two-ctrl-pins.yaml
 
 properties:
   ctx-settle-time-us:

--- a/subsys/mpsl/fem/Kconfig
+++ b/subsys/mpsl/fem/Kconfig
@@ -5,7 +5,7 @@
 #
 
 DT_COMPAT_NORDIC_NRF21540_GPIO := nordic,nrf21540-fem
-DT_COMPAT_GENERIC_FEM_2_CTRL_PIN := generic-fem-two-ctrl-pins
+DT_COMPAT_GENERIC_FEM_2_CTRL_PIN := radio-fem-two-ctrl-pins
 DT_COMPAT_NORDIC_NRF2220 := nordic,nrf2220-fem
 DT_COMPAT_NORDIC_NRF2240 := nordic,nrf2240-fem
 


### PR DESCRIPTION
The generic-fem-two-ctrl-pins was renamed to
radio-fem-two-ctrl-pins.