### PR TITLE
samples: psa_tls: Reserve more memory for nRF54L15

### DIFF
--- a/samples/crypto/psa_tls/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/samples/crypto/psa_tls/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+&rram_controller {
+	/delete-node/ cpuflpr_sram;
+	/delete-node/ cpuflpr_rram;
+};
+
+/* Adjust the cpuapp_sram to include the freed up cpuflpr_sram */
+&cpuapp_sram {
+	reg = <0x20000000 DT_SIZE_K(256)>;
+	ranges = <0x0 0x20000000 0x20040000>;
+};
+
+/* Adjust the cpuapp_rram to include the freed up cpuflpr_rram */
+&cpuapp_rram {
+	reg = <0x0 DT_SIZE_K(1536)>;
+};
+
+/ {
+	eth-rtt {
+		compatible = "segger,eth-rtt";
+	};
+};


### PR DESCRIPTION
Reserve more memory for nRF54L15 for psa_tls sample by freeing up flipper RAM and RRAM.