### PR TITLE
applications: connectivity_bridge: update DAP API usage.

### DIFF
--- a/applications/connectivity_bridge/src/modules/usb_bulk_commands.c
+++ b/applications/connectivity_bridge/src/modules/usb_bulk_commands.c
@@ -13,6 +13,7 @@
 #include <ncs_commit.h>
 
 #include <cmsis_dap.h>
+#include <zephyr/dap/dap_link.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(bulk_commands, CONFIG_BRIDGE_BULK_LOG_LEVEL);
@@ -102,12 +103,12 @@ static void nrf53_reset_work_handler(struct k_work *work)
 /* This is a placeholder implementation until proper CMSIS-DAP support is available.
  * Only custom vendor commands are supported.
  */
-size_t dap_execute_vendor_cmd(uint8_t *in, uint8_t *out)
+size_t dap_execute_vendor_cmd(struct dap_link_context *const dap_link_ctx, uint8_t *in, uint8_t *out)
 {
 	LOG_DBG("got command 0x%02X", in[0]);
 
 	if (in[0] < ID_DAP_VENDOR0) {
-		return dap_execute_cmd(in, out);
+		return dap_link_execute_cmd(dap_link_ctx, in, out);
 	}
 
 #if IS_ENABLED(CONFIG_RETENTION_BOOT_MODE)

--- a/applications/connectivity_bridge/src/modules/usb_bulk_interface.c
+++ b/applications/connectivity_bridge/src/modules/usb_bulk_interface.c
@@ -25,6 +25,9 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_BRIDGE_BULK_LOG_LEVEL);
 #include "usb_bulk_msosv2.h"
 
 #include <cmsis_dap.h>
+#include <zephyr/dap/dap_link.h>
+
+DAP_LINK_CONTEXT_DEFINE(usb_dap_ctx, DEVICE_DT_GET_ONE(zephyr_swdp_gpio));
 
 #define USB_BULK_PACKET_SIZE  64
 #define USB_BULK_PACKET_COUNT 4
@@ -177,7 +180,7 @@ static int dap_usb_process(void)
 #if defined(CONFIG_BRIDGE_CMSIS_DAP_NORDIC_COMMANDS)
 	len = dap_execute_vendor_cmd(buf->data, tx_buf);
 #else
-	len = dap_execute_cmd(buf->data, tx_buf);
+	len = dap_link_execute_cmd(&usb_dap_ctx, buf->data, tx_buf);
 #endif /* defined(CONFIG_BRIDGE_CMSIS_DAP_NORDIC_COMMANDS) */
 	LOG_DBG("response length %u, starting with [0x%02X, 0x%02X]", len, tx_buf[0], tx_buf[1]);
 	net_buf_unref(buf);
@@ -225,7 +228,7 @@ static bool app_event_handler(const struct app_event_header *aeh)
 				LOG_ERR("SWD device is not ready");
 			}
 
-			int ret = dap_setup(swd_dev);
+			int ret = dap_link_init(&usb_dap_ctx);
 
 			if (ret) {
 				LOG_ERR("Failed to initialize DAP controller, %d", ret);


### PR DESCRIPTION
The Zephyr DAP Link library has been refactored, need to change some function calls to stay compatible.