### PR TITLE
subsys/mgmt/mcumgr/grp/img_mgmt: Update library name to match upstrea…

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/CMakeLists.txt
@@ -1,11 +1,13 @@
 #
-# Copyright (c) 2025 Nordic Semiconductor ASA
+# Copyright (c) 2025 - 2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 if(CONFIG_MCUMGR_GRP_IMG_NRF)
-  zephyr_library_amend()
+  # Amend the image management group library
+  set(ZEPHYR_CURRENT_LIBRARY "mcumgr_grp_img_mgmt")
+
   zephyr_library_sources(
     src/img_mgmt.c
     src/img_mgmt_state.c

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/CMakeLists.txt
@@ -1,15 +1,17 @@
 #
-# Copyright (c) 2024-2025 Nordic Semiconductor ASA
+# Copyright (c) 2024-2026 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
 if(CONFIG_MCUMGR_GRP_OS_BOOTLOADER_INFO_B0_ACTIVE_SLOT)
-  zephyr_library_amend()
+  # Amend the os management group library
+  set(ZEPHYR_CURRENT_LIBRARY "mcumgr_grp_os_mgmt")
   zephyr_library_sources(src/os_mgmt_b0_active_slot.c)
 endif()
 
 if(CONFIG_MCUMGR_GRP_OS_REBOOT_BT)
-  zephyr_library_amend()
+  # Amend the os management group library
+  set(ZEPHYR_CURRENT_LIBRARY "mcumgr_grp_os_mgmt")
   zephyr_library_sources(src/os_mgmt_reboot_bt.c)
 endif()


### PR DESCRIPTION
…m name

Upstream library was renamed to "mcumgr_grp_img_mgmt" from being defined by path and so change required here to match.