### PR TITLE
sysbuild: Disable SB_CONFIG_MCUBOOT_DIRECT_XIP_GENERATE_VARIANT

### DIFF
--- a/sysbuild/Kconfig.mcuboot
+++ b/sysbuild/Kconfig.mcuboot
@@ -56,6 +56,11 @@ config MCUBOOT_BUILD_DIRECT_XIP_VARIANT
 	help
 	  Will build the alternative slot (variant) image of the main application.
 
+# Disable generating the alternative slot (variant) image of the main application
+# from Zephyr. NCS relies on own variant image generation.
+configdefault MCUBOOT_DIRECT_XIP_GENERATE_VARIANT
+	default n
+
 menuconfig MCUBOOT_HARDWARE_DOWNGRADE_PREVENTION
 	bool "Downgrade prevention using hardware security counters"
 	depends on (SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91 || SOC_SERIES_NRF54L || SOC_SERIES_NRF54H)


### PR DESCRIPTION
Change disables generating the alternative slot (variant) image of the main application from Zephyr. NCS relies on own variant image generation.

Jira: NCSDK-37306