### PR TITLE
.github: workflows: compliance: disable check with reuse

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -69,7 +69,7 @@ jobs:
         git log --pretty=oneline | head -n 10
         $ZEPHYR_BASE/scripts/ci/check_compliance.py --annotate \
         -e KconfigBasicNoModules -e ClangFormat -e SysbuildKconfigBasicNoModules \
-        -c origin/${BASE_REF}..
+        -e LicenseAndCopyrightCheck -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4


### PR DESCRIPTION
Disable LicenseAndCopyrightCheck and it uses zephyr rules for licenses. sdk-nrf has it own scripts for that.